### PR TITLE
Use correct sort index for linux cost

### DIFF
--- a/www/default.js
+++ b/www/default.js
@@ -23,7 +23,7 @@ function init_data_table() {
     ],
     // default sort by linux cost
     "aaSorting": [
-      [ 8, "asc" ]
+      [ 9, "asc" ]
     ],
     'initComplete': function() {
       // fire event in separate context so that calls to get_data_table()


### PR DESCRIPTION
Splitting up the cpu column into ECU + Cores shifted linux cost along by one and the default sort index wasn't changed accordingly. This uses the right index.