### PR TITLE
Add max bandwidth for EBS optimized instances

### DIFF
--- a/in/index.html.mako
+++ b/in/index.html.mako
@@ -100,6 +100,7 @@
           <th class="storage">Storage</th>
           <th class="architecture">Arch</th>
           <th class="networkperf">Network Performance</th>
+          <th class="max_bandwidth">Max Bandwidth (MB/s)</th>
           <th class="ebs-throughput">EBS Optimized Throughput (Mbps)</th>
           <th class="ebs-iops">Max EBS Optimized 16K IOPS</th>
           <th class="maxips">
@@ -159,6 +160,15 @@
             <span sort="${inst['network_sort']}">
               ${inst['network_performance']}
             </span>
+          </td>
+          <td class="max_bandwidth">
+            % if not inst['max_bandwidth']:
+            <span sort="0">N/A</span>
+            % else:
+            <span sort="${inst['max_bandwidth']}">
+              ${inst['max_bandwidth']}
+            </span>
+            % endif
           </td>
           <td class="ebs-throughput">
             <span sort="${inst['ebs_throughput']}">

--- a/scrape.py
+++ b/scrape.py
@@ -13,6 +13,7 @@ class Instance(object):
         self.linux_virtualization_types = []
         self.ebs_throughput = 0
         self.ebs_iops = 0
+        self.max_bandwidth = 0
 
     def to_dict(self):
         d = dict(family=self.family,
@@ -24,6 +25,7 @@ class Instance(object):
                  ebs_optimized=self.ebs_optimized,
                  ebs_throughput=self.ebs_throughput,
                  ebs_iops=self.ebs_iops,
+                 max_bandwidth=self.max_bandwidth,
                  network_performance=self.network_performance,
                  enhanced_networking=self.enhanced_networking,
                  pricing=self.pricing,
@@ -259,12 +261,13 @@ def add_ebs_info(instances):
         instance_type = totext(cols[0]).split(' ')[0]
         ebs_throughput = int(totext(cols[1]).strip().replace(',', ''))
         ebs_iops = int(totext(cols[2]).strip().replace(',', ''))
+        max_bandwidth = float(totext(cols[3]).strip().replace(',', ''))
         if instance_type not in by_type:
             print "Unknown instance type: " + instance_type
             continue
         by_type[instance_type].ebs_throughput = ebs_throughput
         by_type[instance_type].ebs_iops = ebs_iops
-
+        by_type[instance_type].max_bandwidth = max_bandwidth
 
 
 def add_linux_ami_info(instances):

--- a/www/default.js
+++ b/www/default.js
@@ -13,11 +13,11 @@ function init_data_table() {
     },
     "aoColumnDefs": [
       {
-        "aTargets": ["memory", "computeunits", "cores", "coreunits", "storage", "ebs-throughput", "ebs-iops", "networkperf"],
+        "aTargets": ["memory", "computeunits", "cores", "coreunits", "storage", "ebs-throughput", "ebs-iops", "networkperf", "max_bandwidth"],
         "sType": "span-sort"
       },
       {
-        "aTargets": ["ecu-per-core", "enhanced-networking", "maxips", "linux-virtualization", "cost-mswinSQLWeb", "cost-mswinSQL", "ebs-throughput", "ebs-iops"],
+        "aTargets": ["ecu-per-core", "enhanced-networking", "maxips", "linux-virtualization", "cost-mswinSQLWeb", "cost-mswinSQL", "ebs-throughput", "ebs-iops", "max_bandwidth"],
         "bVisible": false
       }
     ],

--- a/www/index.html
+++ b/www/index.html
@@ -98,6 +98,7 @@
           <th class="storage">Storage</th>
           <th class="architecture">Arch</th>
           <th class="networkperf">Network Performance</th>
+          <th class="max_bandwidth">Max Bandwidth (MB/s)</th>
           <th class="ebs-throughput">EBS Optimized Throughput (Mbps)</th>
           <th class="ebs-iops">Max EBS Optimized 16K IOPS</th>
           <th class="maxips">
@@ -141,6 +142,9 @@
             <span sort="2">
               Low
             </span>
+          </td>
+          <td class="max_bandwidth">
+            <span sort="0">N/A</span>
           </td>
           <td class="ebs-throughput">
             <span sort="0">
@@ -204,6 +208,9 @@
               Moderate
             </span>
           </td>
+          <td class="max_bandwidth">
+            <span sort="0">N/A</span>
+          </td>
           <td class="ebs-throughput">
             <span sort="0">
               0
@@ -264,6 +271,11 @@
           <td class="networkperf">
             <span sort="7">
               Moderate
+            </span>
+          </td>
+          <td class="max_bandwidth">
+            <span sort="62.5">
+              62.5
             </span>
           </td>
           <td class="ebs-throughput">
@@ -328,6 +340,11 @@
               High
             </span>
           </td>
+          <td class="max_bandwidth">
+            <span sort="125.0">
+              125.0
+            </span>
+          </td>
           <td class="ebs-throughput">
             <span sort="1000">
               1000
@@ -390,6 +407,9 @@
               Moderate
             </span>
           </td>
+          <td class="max_bandwidth">
+            <span sort="0">N/A</span>
+          </td>
           <td class="ebs-throughput">
             <span sort="0">
               0
@@ -450,6 +470,11 @@
           <td class="networkperf">
             <span sort="9">
               High
+            </span>
+          </td>
+          <td class="max_bandwidth">
+            <span sort="125.0">
+              125.0
             </span>
           </td>
           <td class="ebs-throughput">
@@ -514,6 +539,9 @@
               10 Gigabit
             </span>
           </td>
+          <td class="max_bandwidth">
+            <span sort="0">N/A</span>
+          </td>
           <td class="ebs-throughput">
             <span sort="0">
               0
@@ -575,6 +603,9 @@
             <span sort="10">
               10 Gigabit
             </span>
+          </td>
+          <td class="max_bandwidth">
+            <span sort="0">N/A</span>
           </td>
           <td class="ebs-throughput">
             <span sort="0">
@@ -638,6 +669,9 @@
               Moderate
             </span>
           </td>
+          <td class="max_bandwidth">
+            <span sort="0">N/A</span>
+          </td>
           <td class="ebs-throughput">
             <span sort="0">
               0
@@ -698,6 +732,11 @@
           <td class="networkperf">
             <span sort="7">
               Moderate
+            </span>
+          </td>
+          <td class="max_bandwidth">
+            <span sort="62.5">
+              62.5
             </span>
           </td>
           <td class="ebs-throughput">
@@ -762,6 +801,11 @@
               High
             </span>
           </td>
+          <td class="max_bandwidth">
+            <span sort="125.0">
+              125.0
+            </span>
+          </td>
           <td class="ebs-throughput">
             <span sort="1000">
               1000
@@ -823,6 +867,9 @@
             <span sort="10">
               10 Gigabit
             </span>
+          </td>
+          <td class="max_bandwidth">
+            <span sort="0">N/A</span>
           </td>
           <td class="ebs-throughput">
             <span sort="0">
@@ -886,6 +933,9 @@
               10 Gigabit
             </span>
           </td>
+          <td class="max_bandwidth">
+            <span sort="0">N/A</span>
+          </td>
           <td class="ebs-throughput">
             <span sort="0">
               0
@@ -948,6 +998,9 @@
               10 Gigabit
             </span>
           </td>
+          <td class="max_bandwidth">
+            <span sort="0">N/A</span>
+          </td>
           <td class="ebs-throughput">
             <span sort="0">
               0
@@ -1007,6 +1060,9 @@
             <span sort="0">
               Very Low
             </span>
+          </td>
+          <td class="max_bandwidth">
+            <span sort="0">N/A</span>
           </td>
           <td class="ebs-throughput">
             <span sort="0">
@@ -1068,6 +1124,9 @@
               Low to Moderate
             </span>
           </td>
+          <td class="max_bandwidth">
+            <span sort="0">N/A</span>
+          </td>
           <td class="ebs-throughput">
             <span sort="0">
               0
@@ -1128,6 +1187,9 @@
               Low to Moderate
             </span>
           </td>
+          <td class="max_bandwidth">
+            <span sort="0">N/A</span>
+          </td>
           <td class="ebs-throughput">
             <span sort="0">
               0
@@ -1187,6 +1249,9 @@
             <span sort="4">
               Low to Moderate
             </span>
+          </td>
+          <td class="max_bandwidth">
+            <span sort="0">N/A</span>
           </td>
           <td class="ebs-throughput">
             <span sort="0">
@@ -1250,6 +1315,9 @@
               Moderate
             </span>
           </td>
+          <td class="max_bandwidth">
+            <span sort="0">N/A</span>
+          </td>
           <td class="ebs-throughput">
             <span sort="0">
               0
@@ -1312,6 +1380,9 @@
               Moderate
             </span>
           </td>
+          <td class="max_bandwidth">
+            <span sort="0">N/A</span>
+          </td>
           <td class="ebs-throughput">
             <span sort="0">
               0
@@ -1372,6 +1443,11 @@
           <td class="networkperf">
             <span sort="9">
               High
+            </span>
+          </td>
+          <td class="max_bandwidth">
+            <span sort="62.5">
+              62.5
             </span>
           </td>
           <td class="ebs-throughput">
@@ -1436,6 +1512,11 @@
               High
             </span>
           </td>
+          <td class="max_bandwidth">
+            <span sort="125.0">
+              125.0
+            </span>
+          </td>
           <td class="ebs-throughput">
             <span sort="1000">
               1000
@@ -1493,6 +1574,11 @@
           <td class="networkperf">
             <span sort="7">
               Moderate
+            </span>
+          </td>
+          <td class="max_bandwidth">
+            <span sort="62.5">
+              62.5
             </span>
           </td>
           <td class="ebs-throughput">
@@ -1554,6 +1640,11 @@
               High
             </span>
           </td>
+          <td class="max_bandwidth">
+            <span sort="93.75">
+              93.75
+            </span>
+          </td>
           <td class="ebs-throughput">
             <span sort="750">
               750
@@ -1611,6 +1702,11 @@
           <td class="networkperf">
             <span sort="9">
               High
+            </span>
+          </td>
+          <td class="max_bandwidth">
+            <span sort="125.0">
+              125.0
             </span>
           </td>
           <td class="ebs-throughput">
@@ -1672,6 +1768,11 @@
               High
             </span>
           </td>
+          <td class="max_bandwidth">
+            <span sort="250.0">
+              250.0
+            </span>
+          </td>
           <td class="ebs-throughput">
             <span sort="2000">
               2000
@@ -1729,6 +1830,11 @@
           <td class="networkperf">
             <span sort="11">
               10 Gigabit
+            </span>
+          </td>
+          <td class="max_bandwidth">
+            <span sort="500.0">
+              500.0
             </span>
           </td>
           <td class="ebs-throughput">
@@ -1793,6 +1899,9 @@
               Moderate
             </span>
           </td>
+          <td class="max_bandwidth">
+            <span sort="0">N/A</span>
+          </td>
           <td class="ebs-throughput">
             <span sort="0">
               0
@@ -1853,6 +1962,11 @@
           <td class="networkperf">
             <span sort="7">
               Moderate
+            </span>
+          </td>
+          <td class="max_bandwidth">
+            <span sort="62.5">
+              62.5
             </span>
           </td>
           <td class="ebs-throughput">
@@ -1917,6 +2031,11 @@
               High
             </span>
           </td>
+          <td class="max_bandwidth">
+            <span sort="125.0">
+              125.0
+            </span>
+          </td>
           <td class="ebs-throughput">
             <span sort="1000">
               1000
@@ -1977,6 +2096,11 @@
           <td class="networkperf">
             <span sort="9">
               High
+            </span>
+          </td>
+          <td class="max_bandwidth">
+            <span sort="250.0">
+              250.0
             </span>
           </td>
           <td class="ebs-throughput">
@@ -2041,6 +2165,9 @@
               10 Gigabit
             </span>
           </td>
+          <td class="max_bandwidth">
+            <span sort="0">N/A</span>
+          </td>
           <td class="ebs-throughput">
             <span sort="0">
               0
@@ -2103,6 +2230,11 @@
               High
             </span>
           </td>
+          <td class="max_bandwidth">
+            <span sort="125.0">
+              125.0
+            </span>
+          </td>
           <td class="ebs-throughput">
             <span sort="1000">
               1000
@@ -2122,17 +2254,82 @@
           <td class="linux-virtualization">
             HVM (Graphics)
           </td>
-          <td class="cost cost-linux" data-pricing='{&#34;us-east-1&#34;: &#34;0.650&#34;, &#34;ap-northeast-1&#34;: &#34;0.898&#34;, &#34;ap-southeast-1&#34;: &#34;1.000&#34;, &#34;ap-southeast-2&#34;: &#34;0.898&#34;, &#34;us-west-2&#34;: &#34;0.650&#34;, &#34;us-west-1&#34;: &#34;0.702&#34;, &#34;eu-central-1&#34;: null, &#34;eu-west-1&#34;: &#34;0.702&#34;}'>
+          <td class="cost cost-linux" data-pricing='{&#34;us-east-1&#34;: &#34;0.650&#34;, &#34;ap-northeast-1&#34;: &#34;0.898&#34;, &#34;ap-southeast-1&#34;: &#34;1.000&#34;, &#34;ap-southeast-2&#34;: &#34;0.898&#34;, &#34;us-west-2&#34;: &#34;0.650&#34;, &#34;us-west-1&#34;: &#34;0.702&#34;, &#34;eu-central-1&#34;: &#34;0.772&#34;, &#34;eu-west-1&#34;: &#34;0.702&#34;}'>
                  $0.650 per hour
           </td>
-          <td class="cost cost-mswin" data-pricing='{&#34;us-east-1&#34;: &#34;0.767&#34;, &#34;ap-northeast-1&#34;: &#34;1.010&#34;, &#34;ap-southeast-1&#34;: &#34;1.160&#34;, &#34;ap-southeast-2&#34;: &#34;1.058&#34;, &#34;us-west-2&#34;: &#34;0.767&#34;, &#34;us-west-1&#34;: &#34;0.819&#34;, &#34;eu-central-1&#34;: 0, &#34;eu-west-1&#34;: &#34;0.767&#34;}'>
+          <td class="cost cost-mswin" data-pricing='{&#34;us-east-1&#34;: &#34;0.767&#34;, &#34;ap-northeast-1&#34;: &#34;1.010&#34;, &#34;ap-southeast-1&#34;: &#34;1.160&#34;, &#34;ap-southeast-2&#34;: &#34;1.058&#34;, &#34;us-west-2&#34;: &#34;0.767&#34;, &#34;us-west-1&#34;: &#34;0.819&#34;, &#34;eu-central-1&#34;: &#34;0.906&#34;, &#34;eu-west-1&#34;: &#34;0.767&#34;}'>
                  $0.767 per hour
           </td>
-          <td class="cost cost-mswinSQLWeb" data-pricing='{&#34;us-east-1&#34;: &#34;0.957&#34;, &#34;ap-northeast-1&#34;: &#34;1.190&#34;, &#34;ap-southeast-1&#34;: &#34;1.307&#34;, &#34;ap-southeast-2&#34;: &#34;1.205&#34;, &#34;us-west-2&#34;: &#34;0.957&#34;, &#34;us-west-1&#34;: &#34;1.009&#34;, &#34;eu-central-1&#34;: 0, &#34;eu-west-1&#34;: &#34;0.957&#34;}'>
+          <td class="cost cost-mswinSQLWeb" data-pricing='{&#34;us-east-1&#34;: &#34;0.957&#34;, &#34;ap-northeast-1&#34;: &#34;1.190&#34;, &#34;ap-southeast-1&#34;: &#34;1.307&#34;, &#34;ap-southeast-2&#34;: &#34;1.205&#34;, &#34;us-west-2&#34;: &#34;0.957&#34;, &#34;us-west-1&#34;: &#34;1.009&#34;, &#34;eu-central-1&#34;: &#34;N/A&#34;, &#34;eu-west-1&#34;: &#34;0.957&#34;}'>
                  $0.957 per hour
           </td>
-          <td class="cost cost-mswinSQL" data-pricing='{&#34;us-east-1&#34;: &#34;3.816&#34;, &#34;ap-northeast-1&#34;: &#34;3.913&#34;, &#34;ap-southeast-1&#34;: &#34;4.166&#34;, &#34;ap-southeast-2&#34;: &#34;4.064&#34;, &#34;us-west-2&#34;: &#34;3.816&#34;, &#34;us-west-1&#34;: &#34;3.868&#34;, &#34;eu-central-1&#34;: 0, &#34;eu-west-1&#34;: &#34;3.816&#34;}'>
+          <td class="cost cost-mswinSQL" data-pricing='{&#34;us-east-1&#34;: &#34;3.816&#34;, &#34;ap-northeast-1&#34;: &#34;3.913&#34;, &#34;ap-southeast-1&#34;: &#34;4.166&#34;, &#34;ap-southeast-2&#34;: &#34;4.064&#34;, &#34;us-west-2&#34;: &#34;3.816&#34;, &#34;us-west-1&#34;: &#34;3.868&#34;, &#34;eu-central-1&#34;: &#34;N/A&#34;, &#34;eu-west-1&#34;: &#34;3.816&#34;}'>
                  $3.816 per hour
+          </td>
+        </tr>
+        <tr class='instance' id="g2.8xlarge">
+          <td class="name">G2 Eight Extra Large</td>
+          <td class="apiname">g2.8xlarge</td>
+          <td class="memory"><span sort="60.0">60.0 GB</span></td>
+          <td class="computeunits">
+            <span sort="104.0">104 units</span>
+          </td>
+          <td class="cores">
+            <span sort="32">
+              32 cores
+            </span>
+          </td>
+          <td class="ecu-per-core">
+            <span sort="3.25">3.25 units</span>
+          </td>
+          <td class="storage">
+            
+            <span sort="240">
+              240 GB
+              (2 * 120 GB SSD)
+            </span>
+          </td>
+          <td class="architecture">
+            64-bit
+          </td>
+          <td class="networkperf">
+            <span sort="10">
+              10 Gigabit
+            </span>
+          </td>
+          <td class="max_bandwidth">
+            <span sort="0">N/A</span>
+          </td>
+          <td class="ebs-throughput">
+            <span sort="0">
+              0
+            </span>
+          </td>
+          <td class="ebs-iops">
+            <span sort="0">
+              0
+            </span>
+          </td>
+          <td class="maxips">
+              240
+          </td>
+          <td class="enhanced-networking">
+            No
+          </td>
+          <td class="linux-virtualization">
+            HVM (Graphics)
+          </td>
+          <td class="cost cost-linux" data-pricing='{&#34;us-east-1&#34;: &#34;2.600&#34;, &#34;ap-northeast-1&#34;: &#34;3.592&#34;, &#34;ap-southeast-1&#34;: &#34;4.000&#34;, &#34;ap-southeast-2&#34;: &#34;3.592&#34;, &#34;us-west-2&#34;: &#34;2.600&#34;, &#34;us-west-1&#34;: &#34;2.808&#34;, &#34;eu-central-1&#34;: &#34;3.088&#34;, &#34;eu-west-1&#34;: &#34;2.808&#34;}'>
+                 $2.600 per hour
+          </td>
+          <td class="cost cost-mswin" data-pricing='{&#34;us-east-1&#34;: &#34;2.878&#34;, &#34;ap-northeast-1&#34;: &#34;3.870&#34;, &#34;ap-southeast-1&#34;: &#34;4.278&#34;, &#34;ap-southeast-2&#34;: &#34;3.870&#34;, &#34;us-west-2&#34;: &#34;2.878&#34;, &#34;us-west-1&#34;: &#34;3.086&#34;, &#34;eu-central-1&#34;: &#34;3.366&#34;, &#34;eu-west-1&#34;: &#34;3.086&#34;}'>
+                 $2.878 per hour
+          </td>
+          <td class="cost cost-mswinSQLWeb" data-pricing='{&#34;us-east-1&#34;: 0, &#34;ap-northeast-1&#34;: 0, &#34;ap-southeast-1&#34;: 0, &#34;ap-southeast-2&#34;: 0, &#34;us-west-2&#34;: 0, &#34;us-west-1&#34;: 0, &#34;eu-central-1&#34;: &#34;N/A&#34;, &#34;eu-west-1&#34;: 0}'>
+            unavailable
+          </td>
+          <td class="cost cost-mswinSQL" data-pricing='{&#34;us-east-1&#34;: 0, &#34;ap-northeast-1&#34;: 0, &#34;ap-southeast-1&#34;: 0, &#34;ap-southeast-2&#34;: 0, &#34;us-west-2&#34;: 0, &#34;us-west-1&#34;: 0, &#34;eu-central-1&#34;: &#34;N/A&#34;, &#34;eu-west-1&#34;: 0}'>
+            unavailable
           </td>
         </tr>
         <tr class='instance' id="r3.large">
@@ -2164,6 +2361,9 @@
             <span sort="6">
               Moderate
             </span>
+          </td>
+          <td class="max_bandwidth">
+            <span sort="0">N/A</span>
           </td>
           <td class="ebs-throughput">
             <span sort="0">
@@ -2225,6 +2425,11 @@
           <td class="networkperf">
             <span sort="7">
               Moderate
+            </span>
+          </td>
+          <td class="max_bandwidth">
+            <span sort="62.5">
+              62.5
             </span>
           </td>
           <td class="ebs-throughput">
@@ -2289,6 +2494,11 @@
               High
             </span>
           </td>
+          <td class="max_bandwidth">
+            <span sort="125.0">
+              125.0
+            </span>
+          </td>
           <td class="ebs-throughput">
             <span sort="1000">
               1000
@@ -2349,6 +2559,11 @@
           <td class="networkperf">
             <span sort="9">
               High
+            </span>
+          </td>
+          <td class="max_bandwidth">
+            <span sort="250.0">
+              250.0
             </span>
           </td>
           <td class="ebs-throughput">
@@ -2413,6 +2628,9 @@
               10 Gigabit
             </span>
           </td>
+          <td class="max_bandwidth">
+            <span sort="0">N/A</span>
+          </td>
           <td class="ebs-throughput">
             <span sort="0">
               0
@@ -2473,6 +2691,11 @@
           <td class="networkperf">
             <span sort="7">
               Moderate
+            </span>
+          </td>
+          <td class="max_bandwidth">
+            <span sort="62.5">
+              62.5
             </span>
           </td>
           <td class="ebs-throughput">
@@ -2537,6 +2760,11 @@
               High
             </span>
           </td>
+          <td class="max_bandwidth">
+            <span sort="125.0">
+              125.0
+            </span>
+          </td>
           <td class="ebs-throughput">
             <span sort="1000">
               1000
@@ -2597,6 +2825,11 @@
           <td class="networkperf">
             <span sort="9">
               High
+            </span>
+          </td>
+          <td class="max_bandwidth">
+            <span sort="250.0">
+              250.0
             </span>
           </td>
           <td class="ebs-throughput">
@@ -2661,6 +2894,9 @@
               10 Gigabit
             </span>
           </td>
+          <td class="max_bandwidth">
+            <span sort="0">N/A</span>
+          </td>
           <td class="ebs-throughput">
             <span sort="0">
               0
@@ -2721,6 +2957,11 @@
           <td class="networkperf">
             <span sort="7">
               Moderate
+            </span>
+          </td>
+          <td class="max_bandwidth">
+            <span sort="93.75">
+              93.75
             </span>
           </td>
           <td class="ebs-throughput">
@@ -2785,6 +3026,11 @@
               High
             </span>
           </td>
+          <td class="max_bandwidth">
+            <span sort="125.0">
+              125.0
+            </span>
+          </td>
           <td class="ebs-throughput">
             <span sort="1000">
               1000
@@ -2845,6 +3091,11 @@
           <td class="networkperf">
             <span sort="9">
               High
+            </span>
+          </td>
+          <td class="max_bandwidth">
+            <span sort="250.0">
+              250.0
             </span>
           </td>
           <td class="ebs-throughput">
@@ -2909,6 +3160,11 @@
               10 Gigabit
             </span>
           </td>
+          <td class="max_bandwidth">
+            <span sort="500.0">
+              500.0
+            </span>
+          </td>
           <td class="ebs-throughput">
             <span sort="4000">
               4000
@@ -2949,7 +3205,7 @@
       <p>It was started by <a href="http://twitter.com/powdahound" target="_blank">@powdahound</a>, contributed to by <a href="https://github.com/powdahound/ec2instances.info/contributors" target="_blank">many</a>, is <a href="http://powdahound.com/2011/03/hosting-a-static-site-on-amazon-s3-ec2instances-info" target="_blank">hosted on S3</a>, and awaits your improvements <a href="https://github.com/powdahound/ec2instances.info" target="_blank">on GitHub</a>.</p>
     </div>
     <div class="well-small">
-      <p class="small">Generated at: 2015-04-02 13:37:50 UTC</p>
+      <p class="small">Generated at: 2015-06-03 10:51:28 UTC</p>
     </div>
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript" charset="utf-8"></script>

--- a/www/instances.json
+++ b/www/instances.json
@@ -3,18 +3,10 @@
     "family": "General Purpose",
     "enhanced_networking": false,
     "vCPU": 1,
-    "storage": {
-      "ssd": false,
-      "devices": 1,
-      "size": 160
-    },
     "generation": "previous",
-    "ebs_optimized": false,
     "ebs_iops": 0,
     "network_performance": "Low",
     "ebs_throughput": 0,
-    "instance_type": "m1.small",
-    "ECU": 1.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "0.139",
@@ -75,31 +67,32 @@
       "ips_per_eni": 4,
       "max_enis": 2
     },
-    "memory": 1.7,
     "arch": [
       "i386",
       "x86_64"
     ],
     "linux_virtualization_types": [
       "PV"
-    ]
+    ],
+    "ebs_optimized": false,
+    "storage": {
+      "ssd": false,
+      "devices": 1,
+      "size": 160
+    },
+    "max_bandwidth": 0,
+    "instance_type": "m1.small",
+    "ECU": 1.0,
+    "memory": 1.7
   },
   {
     "family": "General purpose",
     "enhanced_networking": false,
     "vCPU": 1,
-    "storage": {
-      "ssd": false,
-      "devices": 1,
-      "size": 410
-    },
     "generation": "previous",
-    "ebs_optimized": false,
     "ebs_iops": 0,
     "network_performance": "Moderate",
     "ebs_throughput": 0,
-    "instance_type": "m1.medium",
-    "ECU": 2.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "0.237",
@@ -160,31 +153,32 @@
       "ips_per_eni": 6,
       "max_enis": 2
     },
-    "memory": 3.75,
     "arch": [
       "i386",
       "x86_64"
     ],
     "linux_virtualization_types": [
       "PV"
-    ]
+    ],
+    "ebs_optimized": false,
+    "storage": {
+      "ssd": false,
+      "devices": 1,
+      "size": 410
+    },
+    "max_bandwidth": 0,
+    "instance_type": "m1.medium",
+    "ECU": 2.0,
+    "memory": 3.75
   },
   {
     "family": "General purpose",
     "enhanced_networking": false,
     "vCPU": 2,
-    "storage": {
-      "ssd": false,
-      "devices": 2,
-      "size": 420
-    },
     "generation": "previous",
-    "ebs_optimized": true,
     "ebs_iops": 4000,
     "network_performance": "Moderate",
     "ebs_throughput": 500,
-    "instance_type": "m1.large",
-    "ECU": 4.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "0.435",
@@ -245,30 +239,31 @@
       "ips_per_eni": 10,
       "max_enis": 3
     },
-    "memory": 7.5,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "PV"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": {
+      "ssd": false,
+      "devices": 2,
+      "size": 420
+    },
+    "max_bandwidth": 62.5,
+    "instance_type": "m1.large",
+    "ECU": 4.0,
+    "memory": 7.5
   },
   {
     "family": "General purpose",
     "enhanced_networking": false,
     "vCPU": 4,
-    "storage": {
-      "ssd": false,
-      "devices": 4,
-      "size": 420
-    },
     "generation": "previous",
-    "ebs_optimized": true,
     "ebs_iops": 8000,
     "network_performance": "High",
     "ebs_throughput": 1000,
-    "instance_type": "m1.xlarge",
-    "ECU": 8.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "0.830",
@@ -329,30 +324,31 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
-    "memory": 15.0,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "PV"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": {
+      "ssd": false,
+      "devices": 4,
+      "size": 420
+    },
+    "max_bandwidth": 125.0,
+    "instance_type": "m1.xlarge",
+    "ECU": 8.0,
+    "memory": 15.0
   },
   {
     "family": "Compute optimized",
     "enhanced_networking": false,
     "vCPU": 2,
-    "storage": {
-      "ssd": false,
-      "devices": 1,
-      "size": 350
-    },
     "generation": "previous",
-    "ebs_optimized": false,
     "ebs_iops": 0,
     "network_performance": "Moderate",
     "ebs_throughput": 0,
-    "instance_type": "c1.medium",
-    "ECU": 5.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "0.310",
@@ -412,31 +408,32 @@
       "ips_per_eni": 6,
       "max_enis": 2
     },
-    "memory": 1.7,
     "arch": [
       "i386",
       "x86_64"
     ],
     "linux_virtualization_types": [
       "PV"
-    ]
+    ],
+    "ebs_optimized": false,
+    "storage": {
+      "ssd": false,
+      "devices": 1,
+      "size": 350
+    },
+    "max_bandwidth": 0,
+    "instance_type": "c1.medium",
+    "ECU": 5.0,
+    "memory": 1.7
   },
   {
     "family": "Compute optimized",
     "enhanced_networking": false,
     "vCPU": 8,
-    "storage": {
-      "ssd": false,
-      "devices": 4,
-      "size": 420
-    },
     "generation": "previous",
-    "ebs_optimized": true,
     "ebs_iops": 8000,
     "network_performance": "High",
     "ebs_throughput": 1000,
-    "instance_type": "c1.xlarge",
-    "ECU": 20.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "1.160",
@@ -497,30 +494,31 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
-    "memory": 7.0,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "PV"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": {
+      "ssd": false,
+      "devices": 4,
+      "size": 420
+    },
+    "max_bandwidth": 125.0,
+    "instance_type": "c1.xlarge",
+    "ECU": 20.0,
+    "memory": 7.0
   },
   {
     "family": "Compute optimized",
     "enhanced_networking": false,
     "vCPU": 32,
-    "storage": {
-      "ssd": false,
-      "devices": 4,
-      "size": 840
-    },
     "generation": "previous",
-    "ebs_optimized": false,
     "ebs_iops": 0,
     "network_performance": "10 Gigabit",
     "ebs_throughput": 0,
-    "instance_type": "cc2.8xlarge",
-    "ECU": 88.0,
     "pricing": {
       "us-west-2": {
         "mswinSQLWeb": "2.775",
@@ -557,30 +555,31 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
-    "memory": 60.5,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM"
-    ]
+    ],
+    "ebs_optimized": false,
+    "storage": {
+      "ssd": false,
+      "devices": 4,
+      "size": 840
+    },
+    "max_bandwidth": 0,
+    "instance_type": "cc2.8xlarge",
+    "ECU": 88.0,
+    "memory": 60.5
   },
   {
     "family": "GPU instances",
     "enhanced_networking": false,
     "vCPU": 16,
-    "storage": {
-      "ssd": false,
-      "devices": 2,
-      "size": 840
-    },
     "generation": "previous",
-    "ebs_optimized": false,
     "ebs_iops": 0,
     "network_performance": "10 Gigabit",
     "ebs_throughput": 0,
-    "instance_type": "cg1.4xlarge",
-    "ECU": 33.5,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "2.703",
@@ -599,28 +598,29 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
-    "memory": 22.5,
     "arch": [
       "x86_64"
     ],
-    "linux_virtualization_types": []
+    "linux_virtualization_types": [],
+    "ebs_optimized": false,
+    "storage": {
+      "ssd": false,
+      "devices": 2,
+      "size": 840
+    },
+    "max_bandwidth": 0,
+    "instance_type": "cg1.4xlarge",
+    "ECU": 33.5,
+    "memory": 22.5
   },
   {
     "family": "Memory optimized",
     "enhanced_networking": false,
     "vCPU": 2,
-    "storage": {
-      "ssd": false,
-      "devices": 1,
-      "size": 420
-    },
     "generation": "previous",
-    "ebs_optimized": false,
     "ebs_iops": 0,
     "network_performance": "Moderate",
     "ebs_throughput": 0,
-    "instance_type": "m2.xlarge",
-    "ECU": 6.5,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "0.445",
@@ -681,30 +681,31 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
-    "memory": 17.1,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "PV"
-    ]
+    ],
+    "ebs_optimized": false,
+    "storage": {
+      "ssd": false,
+      "devices": 1,
+      "size": 420
+    },
+    "max_bandwidth": 0,
+    "instance_type": "m2.xlarge",
+    "ECU": 6.5,
+    "memory": 17.1
   },
   {
     "family": "Memory optimized",
     "enhanced_networking": false,
     "vCPU": 4,
-    "storage": {
-      "ssd": false,
-      "devices": 1,
-      "size": 850
-    },
     "generation": "previous",
-    "ebs_optimized": true,
     "ebs_iops": 4000,
     "network_performance": "Moderate",
     "ebs_throughput": 500,
-    "instance_type": "m2.2xlarge",
-    "ECU": 13.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "0.850",
@@ -765,30 +766,31 @@
       "ips_per_eni": 30,
       "max_enis": 4
     },
-    "memory": 34.2,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "PV"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": {
+      "ssd": false,
+      "devices": 1,
+      "size": 850
+    },
+    "max_bandwidth": 62.5,
+    "instance_type": "m2.2xlarge",
+    "ECU": 13.0,
+    "memory": 34.2
   },
   {
     "family": "Memory optimized",
     "enhanced_networking": false,
     "vCPU": 8,
-    "storage": {
-      "ssd": false,
-      "devices": 2,
-      "size": 840
-    },
     "generation": "previous",
-    "ebs_optimized": true,
     "ebs_iops": 8000,
     "network_performance": "High",
     "ebs_throughput": 1000,
-    "instance_type": "m2.4xlarge",
-    "ECU": 26.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "1.700",
@@ -849,30 +851,31 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
-    "memory": 68.4,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "PV"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": {
+      "ssd": false,
+      "devices": 2,
+      "size": 840
+    },
+    "max_bandwidth": 125.0,
+    "instance_type": "m2.4xlarge",
+    "ECU": 26.0,
+    "memory": 68.4
   },
   {
     "family": "Memory optimized",
     "enhanced_networking": false,
     "vCPU": 32,
-    "storage": {
-      "ssd": true,
-      "devices": 2,
-      "size": 120
-    },
     "generation": "previous",
-    "ebs_optimized": false,
     "ebs_iops": 0,
     "network_performance": "10 Gigabit",
     "ebs_throughput": 0,
-    "instance_type": "cr1.8xlarge",
-    "ECU": 88.0,
     "pricing": {
       "us-west-2": {
         "mswinSQLWeb": "4.044",
@@ -903,30 +906,31 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
-    "memory": 244.0,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM"
-    ]
+    ],
+    "ebs_optimized": false,
+    "storage": {
+      "ssd": true,
+      "devices": 2,
+      "size": 120
+    },
+    "max_bandwidth": 0,
+    "instance_type": "cr1.8xlarge",
+    "ECU": 88.0,
+    "memory": 244.0
   },
   {
     "family": "Storage optimized",
     "enhanced_networking": false,
     "vCPU": 16,
-    "storage": {
-      "ssd": true,
-      "devices": 2,
-      "size": 1024
-    },
     "generation": "previous",
-    "ebs_optimized": false,
     "ebs_iops": 0,
     "network_performance": "10 Gigabit",
     "ebs_throughput": 0,
-    "instance_type": "hi1.4xlarge",
-    "ECU": 35.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "3.660",
@@ -986,31 +990,32 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
-    "memory": 60.5,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM",
       "PV"
-    ]
+    ],
+    "ebs_optimized": false,
+    "storage": {
+      "ssd": true,
+      "devices": 2,
+      "size": 1024
+    },
+    "max_bandwidth": 0,
+    "instance_type": "hi1.4xlarge",
+    "ECU": 35.0,
+    "memory": 60.5
   },
   {
     "family": "Storage optimized",
     "enhanced_networking": false,
     "vCPU": 17,
-    "storage": {
-      "ssd": false,
-      "devices": 24,
-      "size": 2000
-    },
     "generation": "previous",
-    "ebs_optimized": false,
     "ebs_iops": 0,
     "network_performance": "10 Gigabit",
     "ebs_throughput": 0,
-    "instance_type": "hs1.8xlarge",
-    "ECU": 35.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "5.144",
@@ -1070,27 +1075,32 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
-    "memory": 117.0,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM",
       "PV"
-    ]
+    ],
+    "ebs_optimized": false,
+    "storage": {
+      "ssd": false,
+      "devices": 24,
+      "size": 2000
+    },
+    "max_bandwidth": 0,
+    "instance_type": "hs1.8xlarge",
+    "ECU": 35.0,
+    "memory": 117.0
   },
   {
     "family": "Micro",
     "enhanced_networking": false,
     "vCPU": 1,
-    "storage": null,
     "generation": "previous",
-    "ebs_optimized": false,
     "ebs_iops": 0,
     "network_performance": "Very Low",
     "ebs_throughput": 0,
-    "instance_type": "t1.micro",
-    "ECU": 0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "0.070",
@@ -1150,27 +1160,28 @@
       "ips_per_eni": 2,
       "max_enis": 2
     },
-    "memory": 0.613,
     "arch": [
       "i386",
       "x86_64"
     ],
     "linux_virtualization_types": [
       "PV"
-    ]
+    ],
+    "ebs_optimized": false,
+    "storage": null,
+    "max_bandwidth": 0,
+    "instance_type": "t1.micro",
+    "ECU": 0,
+    "memory": 0.613
   },
   {
     "family": "General purpose",
     "enhanced_networking": false,
     "vCPU": 1,
-    "storage": null,
     "generation": "current",
-    "ebs_optimized": false,
     "ebs_iops": 0,
     "network_performance": "Low to Moderate",
     "ebs_throughput": 0,
-    "instance_type": "t2.micro",
-    "ECU": 0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "0.068",
@@ -1227,27 +1238,28 @@
       "ips_per_eni": 2,
       "max_enis": 2
     },
-    "memory": 1.0,
     "arch": [
       "x86_64",
       "i386"
     ],
     "linux_virtualization_types": [
       "HVM"
-    ]
+    ],
+    "ebs_optimized": false,
+    "storage": null,
+    "max_bandwidth": 0,
+    "instance_type": "t2.micro",
+    "ECU": 0,
+    "memory": 1.0
   },
   {
     "family": "General purpose",
     "enhanced_networking": false,
     "vCPU": 1,
-    "storage": null,
     "generation": "current",
-    "ebs_optimized": false,
     "ebs_iops": 0,
     "network_performance": "Low to Moderate",
     "ebs_throughput": 0,
-    "instance_type": "t2.small",
-    "ECU": 0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "0.136",
@@ -1304,27 +1316,28 @@
       "ips_per_eni": 4,
       "max_enis": 2
     },
-    "memory": 2.0,
     "arch": [
       "x86_64",
       "i386"
     ],
     "linux_virtualization_types": [
       "HVM"
-    ]
+    ],
+    "ebs_optimized": false,
+    "storage": null,
+    "max_bandwidth": 0,
+    "instance_type": "t2.small",
+    "ECU": 0,
+    "memory": 2.0
   },
   {
     "family": "General purpose",
     "enhanced_networking": false,
     "vCPU": 2,
-    "storage": null,
     "generation": "current",
-    "ebs_optimized": false,
     "ebs_iops": 0,
     "network_performance": "Low to Moderate",
     "ebs_throughput": 0,
-    "instance_type": "t2.medium",
-    "ECU": 0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "0.272",
@@ -1381,30 +1394,27 @@
       "ips_per_eni": 6,
       "max_enis": 3
     },
-    "memory": 4.0,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM"
-    ]
+    ],
+    "ebs_optimized": false,
+    "storage": null,
+    "max_bandwidth": 0,
+    "instance_type": "t2.medium",
+    "ECU": 0,
+    "memory": 4.0
   },
   {
     "family": "General purpose",
     "enhanced_networking": false,
     "vCPU": 1,
-    "storage": {
-      "ssd": true,
-      "devices": 1,
-      "size": 4
-    },
     "generation": "current",
-    "ebs_optimized": false,
     "ebs_iops": 0,
     "network_performance": "Moderate",
     "ebs_throughput": 0,
-    "instance_type": "m3.medium",
-    "ECU": 3.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "0.187",
@@ -1469,31 +1479,32 @@
       "ips_per_eni": 6,
       "max_enis": 2
     },
-    "memory": 3.75,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM",
       "PV"
-    ]
+    ],
+    "ebs_optimized": false,
+    "storage": {
+      "ssd": true,
+      "devices": 1,
+      "size": 4
+    },
+    "max_bandwidth": 0,
+    "instance_type": "m3.medium",
+    "ECU": 3.0,
+    "memory": 3.75
   },
   {
     "family": "General purpose",
     "enhanced_networking": false,
     "vCPU": 2,
-    "storage": {
-      "ssd": true,
-      "devices": 1,
-      "size": 32
-    },
     "generation": "current",
-    "ebs_optimized": false,
     "ebs_iops": 0,
     "network_performance": "Moderate",
     "ebs_throughput": 0,
-    "instance_type": "m3.large",
-    "ECU": 6.5,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "0.374",
@@ -1560,31 +1571,32 @@
       "ips_per_eni": 10,
       "max_enis": 3
     },
-    "memory": 7.5,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM",
       "PV"
-    ]
+    ],
+    "ebs_optimized": false,
+    "storage": {
+      "ssd": true,
+      "devices": 1,
+      "size": 32
+    },
+    "max_bandwidth": 0,
+    "instance_type": "m3.large",
+    "ECU": 6.5,
+    "memory": 7.5
   },
   {
     "family": "General purpose",
     "enhanced_networking": false,
     "vCPU": 4,
-    "storage": {
-      "ssd": true,
-      "devices": 2,
-      "size": 40
-    },
     "generation": "current",
-    "ebs_optimized": true,
     "ebs_iops": 4000,
     "network_performance": "High",
     "ebs_throughput": 500,
-    "instance_type": "m3.xlarge",
-    "ECU": 13.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "0.748",
@@ -1651,31 +1663,32 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
-    "memory": 15.0,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM",
       "PV"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": {
+      "ssd": true,
+      "devices": 2,
+      "size": 40
+    },
+    "max_bandwidth": 62.5,
+    "instance_type": "m3.xlarge",
+    "ECU": 13.0,
+    "memory": 15.0
   },
   {
     "family": "General purpose",
     "enhanced_networking": false,
     "vCPU": 8,
-    "storage": {
-      "ssd": true,
-      "devices": 2,
-      "size": 80
-    },
     "generation": "current",
-    "ebs_optimized": true,
     "ebs_iops": 8000,
     "network_performance": "High",
     "ebs_throughput": 1000,
-    "instance_type": "m3.2xlarge",
-    "ECU": 26.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "1.496",
@@ -1742,27 +1755,32 @@
       "ips_per_eni": 30,
       "max_enis": 4
     },
-    "memory": 30.0,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM",
       "PV"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": {
+      "ssd": true,
+      "devices": 2,
+      "size": 80
+    },
+    "max_bandwidth": 125.0,
+    "instance_type": "m3.2xlarge",
+    "ECU": 26.0,
+    "memory": 30.0
   },
   {
     "family": "Compute optimized",
     "enhanced_networking": true,
     "vCPU": 2,
-    "storage": null,
     "generation": "current",
-    "ebs_optimized": true,
     "ebs_iops": 4000,
     "network_performance": "Moderate",
     "ebs_throughput": 500,
-    "instance_type": "c4.large",
-    "ECU": 8.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "0.424",
@@ -1817,26 +1835,27 @@
       "ips_per_eni": 10,
       "max_enis": 3
     },
-    "memory": 3.75,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": null,
+    "max_bandwidth": 62.5,
+    "instance_type": "c4.large",
+    "ECU": 8.0,
+    "memory": 3.75
   },
   {
     "family": "Compute optimized",
     "enhanced_networking": true,
     "vCPU": 4,
-    "storage": null,
     "generation": "current",
-    "ebs_optimized": true,
     "ebs_iops": 6000,
     "network_performance": "High",
     "ebs_throughput": 750,
-    "instance_type": "c4.xlarge",
-    "ECU": 16.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "0.799",
@@ -1891,26 +1910,27 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
-    "memory": 7.5,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": null,
+    "max_bandwidth": 93.75,
+    "instance_type": "c4.xlarge",
+    "ECU": 16.0,
+    "memory": 7.5
   },
   {
     "family": "Compute optimized",
     "enhanced_networking": true,
     "vCPU": 8,
-    "storage": null,
     "generation": "current",
-    "ebs_optimized": true,
     "ebs_iops": 8000,
     "network_performance": "High",
     "ebs_throughput": 1000,
-    "instance_type": "c4.2xlarge",
-    "ECU": 31.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "1.661",
@@ -1965,26 +1985,27 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
-    "memory": 15.0,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": null,
+    "max_bandwidth": 125.0,
+    "instance_type": "c4.2xlarge",
+    "ECU": 31.0,
+    "memory": 15.0
   },
   {
     "family": "Compute optimized",
     "enhanced_networking": true,
     "vCPU": 16,
-    "storage": null,
     "generation": "current",
-    "ebs_optimized": true,
     "ebs_iops": 16000,
     "network_performance": "High",
     "ebs_throughput": 2000,
-    "instance_type": "c4.4xlarge",
-    "ECU": 62.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "2.279",
@@ -2039,26 +2060,27 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
-    "memory": 30.0,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": null,
+    "max_bandwidth": 250.0,
+    "instance_type": "c4.4xlarge",
+    "ECU": 62.0,
+    "memory": 30.0
   },
   {
     "family": "Compute optimized",
     "enhanced_networking": true,
     "vCPU": 36,
-    "storage": null,
     "generation": "current",
-    "ebs_optimized": true,
     "ebs_iops": 32000,
     "network_performance": "10 Gigabit",
     "ebs_throughput": 4000,
-    "instance_type": "c4.8xlarge",
-    "ECU": 132.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "4.366",
@@ -2113,30 +2135,27 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
-    "memory": 60.0,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": null,
+    "max_bandwidth": 500.0,
+    "instance_type": "c4.8xlarge",
+    "ECU": 132.0,
+    "memory": 60.0
   },
   {
     "family": "Compute optimized",
     "enhanced_networking": true,
     "vCPU": 2,
-    "storage": {
-      "ssd": true,
-      "devices": 2,
-      "size": 16
-    },
     "generation": "current",
-    "ebs_optimized": false,
     "ebs_iops": 0,
     "network_performance": "Moderate",
     "ebs_throughput": 0,
-    "instance_type": "c3.large",
-    "ECU": 7.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "0.271",
@@ -2200,31 +2219,32 @@
       "ips_per_eni": 10,
       "max_enis": 3
     },
-    "memory": 3.75,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM",
       "PV"
-    ]
+    ],
+    "ebs_optimized": false,
+    "storage": {
+      "ssd": true,
+      "devices": 2,
+      "size": 16
+    },
+    "max_bandwidth": 0,
+    "instance_type": "c3.large",
+    "ECU": 7.0,
+    "memory": 3.75
   },
   {
     "family": "Compute optimized",
     "enhanced_networking": true,
     "vCPU": 4,
-    "storage": {
-      "ssd": true,
-      "devices": 2,
-      "size": 40
-    },
     "generation": "current",
-    "ebs_optimized": true,
     "ebs_iops": 4000,
     "network_performance": "Moderate",
     "ebs_throughput": 500,
-    "instance_type": "c3.xlarge",
-    "ECU": 14.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "0.542",
@@ -2291,31 +2311,32 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
-    "memory": 7.5,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM",
       "PV"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": {
+      "ssd": true,
+      "devices": 2,
+      "size": 40
+    },
+    "max_bandwidth": 62.5,
+    "instance_type": "c3.xlarge",
+    "ECU": 14.0,
+    "memory": 7.5
   },
   {
     "family": "Compute optimized",
     "enhanced_networking": true,
     "vCPU": 8,
-    "storage": {
-      "ssd": true,
-      "devices": 2,
-      "size": 80
-    },
     "generation": "current",
-    "ebs_optimized": true,
     "ebs_iops": 8000,
     "network_performance": "High",
     "ebs_throughput": 1000,
-    "instance_type": "c3.2xlarge",
-    "ECU": 28.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "1.083",
@@ -2382,31 +2403,32 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
-    "memory": 15.0,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM",
       "PV"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": {
+      "ssd": true,
+      "devices": 2,
+      "size": 80
+    },
+    "max_bandwidth": 125.0,
+    "instance_type": "c3.2xlarge",
+    "ECU": 28.0,
+    "memory": 15.0
   },
   {
     "family": "Compute optimized",
     "enhanced_networking": true,
     "vCPU": 16,
-    "storage": {
-      "ssd": true,
-      "devices": 2,
-      "size": 160
-    },
     "generation": "current",
-    "ebs_optimized": true,
     "ebs_iops": 16000,
     "network_performance": "High",
     "ebs_throughput": 2000,
-    "instance_type": "c3.4xlarge",
-    "ECU": 55.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "2.166",
@@ -2473,31 +2495,32 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
-    "memory": 30.0,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM",
       "PV"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": {
+      "ssd": true,
+      "devices": 2,
+      "size": 160
+    },
+    "max_bandwidth": 250.0,
+    "instance_type": "c3.4xlarge",
+    "ECU": 55.0,
+    "memory": 30.0
   },
   {
     "family": "Compute optimized",
     "enhanced_networking": true,
     "vCPU": 32,
-    "storage": {
-      "ssd": true,
-      "devices": 2,
-      "size": 320
-    },
     "generation": "current",
-    "ebs_optimized": false,
     "ebs_iops": 0,
     "network_performance": "10 Gigabit",
     "ebs_throughput": 0,
-    "instance_type": "c3.8xlarge",
-    "ECU": 108.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "4.332",
@@ -2564,31 +2587,32 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
-    "memory": 60.0,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM",
       "PV"
-    ]
+    ],
+    "ebs_optimized": false,
+    "storage": {
+      "ssd": true,
+      "devices": 2,
+      "size": 320
+    },
+    "max_bandwidth": 0,
+    "instance_type": "c3.8xlarge",
+    "ECU": 108.0,
+    "memory": 60.0
   },
   {
     "family": "GPU instances",
     "enhanced_networking": false,
     "vCPU": 8,
-    "storage": {
-      "ssd": true,
-      "devices": 1,
-      "size": 60
-    },
     "generation": "current",
-    "ebs_optimized": true,
     "ebs_iops": 8000,
     "network_performance": "High",
     "ebs_throughput": 1000,
-    "instance_type": "g2.2xlarge",
-    "ECU": 26.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "0.957",
@@ -2627,7 +2651,10 @@
         "linux": "0.702"
       },
       "eu-central-1": {
-        "linux": null
+        "mswinSQLWeb": "N/A",
+        "mswinSQL": "N/A",
+        "mswin": "0.906",
+        "linux": "0.772"
       },
       "eu-west-1": {
         "mswinSQLWeb": "0.957",
@@ -2640,30 +2667,96 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
-    "memory": 15.0,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM (Graphics)"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": {
+      "ssd": true,
+      "devices": 1,
+      "size": 60
+    },
+    "max_bandwidth": 125.0,
+    "instance_type": "g2.2xlarge",
+    "ECU": 26.0,
+    "memory": 15.0
+  },
+  {
+    "family": "GPU instances",
+    "enhanced_networking": false,
+    "vCPU": 32,
+    "generation": "current",
+    "ebs_iops": 0,
+    "network_performance": "10 Gigabit",
+    "ebs_throughput": 0,
+    "pricing": {
+      "us-east-1": {
+        "mswin": "2.878",
+        "linux": "2.600"
+      },
+      "ap-northeast-1": {
+        "mswin": "3.870",
+        "linux": "3.592"
+      },
+      "ap-southeast-1": {
+        "mswin": "4.278",
+        "linux": "4.000"
+      },
+      "ap-southeast-2": {
+        "mswin": "3.870",
+        "linux": "3.592"
+      },
+      "us-west-2": {
+        "mswin": "2.878",
+        "linux": "2.600"
+      },
+      "us-west-1": {
+        "mswin": "3.086",
+        "linux": "2.808"
+      },
+      "eu-central-1": {
+        "mswinSQLWeb": "N/A",
+        "mswinSQL": "N/A",
+        "mswin": "3.366",
+        "linux": "3.088"
+      },
+      "eu-west-1": {
+        "mswin": "3.086",
+        "linux": "2.808"
+      }
+    },
+    "vpc": {
+      "ips_per_eni": 30,
+      "max_enis": 8
+    },
+    "arch": [
+      "x86_64"
+    ],
+    "linux_virtualization_types": [
+      "HVM (Graphics)"
+    ],
+    "ebs_optimized": false,
+    "storage": {
+      "ssd": true,
+      "devices": 2,
+      "size": 120
+    },
+    "max_bandwidth": 0,
+    "instance_type": "g2.8xlarge",
+    "ECU": 104.0,
+    "memory": 60.0
   },
   {
     "family": "Memory optimized",
     "enhanced_networking": true,
     "vCPU": 2,
-    "storage": {
-      "ssd": true,
-      "devices": 1,
-      "size": 32
-    },
     "generation": "current",
-    "ebs_optimized": false,
     "ebs_iops": 0,
     "network_performance": "Moderate",
     "ebs_throughput": 0,
-    "instance_type": "r3.large",
-    "ECU": 6.5,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "0.395",
@@ -2724,30 +2817,31 @@
       "ips_per_eni": 10,
       "max_enis": 3
     },
-    "memory": 15.25,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM"
-    ]
+    ],
+    "ebs_optimized": false,
+    "storage": {
+      "ssd": true,
+      "devices": 1,
+      "size": 32
+    },
+    "max_bandwidth": 0,
+    "instance_type": "r3.large",
+    "ECU": 6.5,
+    "memory": 15.25
   },
   {
     "family": "Memory optimized",
     "enhanced_networking": true,
     "vCPU": 4,
-    "storage": {
-      "ssd": true,
-      "devices": 1,
-      "size": 80
-    },
     "generation": "current",
-    "ebs_optimized": true,
     "ebs_iops": 4000,
     "network_performance": "Moderate",
     "ebs_throughput": 500,
-    "instance_type": "r3.xlarge",
-    "ECU": 13.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "0.755",
@@ -2808,30 +2902,31 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
-    "memory": 30.5,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": {
+      "ssd": true,
+      "devices": 1,
+      "size": 80
+    },
+    "max_bandwidth": 62.5,
+    "instance_type": "r3.xlarge",
+    "ECU": 13.0,
+    "memory": 30.5
   },
   {
     "family": "Memory optimized",
     "enhanced_networking": true,
     "vCPU": 8,
-    "storage": {
-      "ssd": true,
-      "devices": 1,
-      "size": 160
-    },
     "generation": "current",
-    "ebs_optimized": true,
     "ebs_iops": 8000,
     "network_performance": "High",
     "ebs_throughput": 1000,
-    "instance_type": "r3.2xlarge",
-    "ECU": 26.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "1.555",
@@ -2892,30 +2987,31 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
-    "memory": 61.0,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": {
+      "ssd": true,
+      "devices": 1,
+      "size": 160
+    },
+    "max_bandwidth": 125.0,
+    "instance_type": "r3.2xlarge",
+    "ECU": 26.0,
+    "memory": 61.0
   },
   {
     "family": "Memory optimized",
     "enhanced_networking": true,
     "vCPU": 16,
-    "storage": {
-      "ssd": true,
-      "devices": 1,
-      "size": 320
-    },
     "generation": "current",
-    "ebs_optimized": true,
     "ebs_iops": 16000,
     "network_performance": "High",
     "ebs_throughput": 2000,
-    "instance_type": "r3.4xlarge",
-    "ECU": 52.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "2.365",
@@ -2976,30 +3072,31 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
-    "memory": 122.0,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": {
+      "ssd": true,
+      "devices": 1,
+      "size": 320
+    },
+    "max_bandwidth": 250.0,
+    "instance_type": "r3.4xlarge",
+    "ECU": 52.0,
+    "memory": 122.0
   },
   {
     "family": "Memory optimized",
     "enhanced_networking": true,
     "vCPU": 32,
-    "storage": {
-      "ssd": true,
-      "devices": 2,
-      "size": 320
-    },
     "generation": "current",
-    "ebs_optimized": false,
     "ebs_iops": 0,
     "network_performance": "10 Gigabit",
     "ebs_throughput": 0,
-    "instance_type": "r3.8xlarge",
-    "ECU": 104.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "3.995",
@@ -3060,30 +3157,31 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
-    "memory": 244.0,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM"
-    ]
+    ],
+    "ebs_optimized": false,
+    "storage": {
+      "ssd": true,
+      "devices": 2,
+      "size": 320
+    },
+    "max_bandwidth": 0,
+    "instance_type": "r3.8xlarge",
+    "ECU": 104.0,
+    "memory": 244.0
   },
   {
     "family": "Storage optimized",
     "enhanced_networking": true,
     "vCPU": 4,
-    "storage": {
-      "ssd": true,
-      "devices": 1,
-      "size": 800
-    },
     "generation": "current",
-    "ebs_optimized": true,
     "ebs_iops": 4000,
     "network_performance": "Moderate",
     "ebs_throughput": 500,
-    "instance_type": "i2.xlarge",
-    "ECU": 14.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "0.993",
@@ -3144,30 +3242,31 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
-    "memory": 30.5,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": {
+      "ssd": true,
+      "devices": 1,
+      "size": 800
+    },
+    "max_bandwidth": 62.5,
+    "instance_type": "i2.xlarge",
+    "ECU": 14.0,
+    "memory": 30.5
   },
   {
     "family": "Storage optimized",
     "enhanced_networking": true,
     "vCPU": 8,
-    "storage": {
-      "ssd": true,
-      "devices": 2,
-      "size": 800
-    },
     "generation": "current",
-    "ebs_optimized": true,
     "ebs_iops": 8000,
     "network_performance": "High",
     "ebs_throughput": 1000,
-    "instance_type": "i2.2xlarge",
-    "ECU": 27.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "1.986",
@@ -3228,30 +3327,31 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
-    "memory": 61.0,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": {
+      "ssd": true,
+      "devices": 2,
+      "size": 800
+    },
+    "max_bandwidth": 125.0,
+    "instance_type": "i2.2xlarge",
+    "ECU": 27.0,
+    "memory": 61.0
   },
   {
     "family": "Storage optimized",
     "enhanced_networking": true,
     "vCPU": 16,
-    "storage": {
-      "ssd": true,
-      "devices": 4,
-      "size": 800
-    },
     "generation": "current",
-    "ebs_optimized": true,
     "ebs_iops": 16000,
     "network_performance": "High",
     "ebs_throughput": 2000,
-    "instance_type": "i2.4xlarge",
-    "ECU": 53.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "3.971",
@@ -3312,30 +3412,31 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
-    "memory": 122.0,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": {
+      "ssd": true,
+      "devices": 4,
+      "size": 800
+    },
+    "max_bandwidth": 250.0,
+    "instance_type": "i2.4xlarge",
+    "ECU": 53.0,
+    "memory": 122.0
   },
   {
     "family": "Storage optimized",
     "enhanced_networking": true,
     "vCPU": 32,
-    "storage": {
-      "ssd": true,
-      "devices": 8,
-      "size": 800
-    },
     "generation": "current",
-    "ebs_optimized": false,
     "ebs_iops": 0,
     "network_performance": "10 Gigabit",
     "ebs_throughput": 0,
-    "instance_type": "i2.8xlarge",
-    "ECU": 104.0,
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "7.942",
@@ -3396,30 +3497,31 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
-    "memory": 244.0,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM"
-    ]
+    ],
+    "ebs_optimized": false,
+    "storage": {
+      "ssd": true,
+      "devices": 8,
+      "size": 800
+    },
+    "max_bandwidth": 0,
+    "instance_type": "i2.8xlarge",
+    "ECU": 104.0,
+    "memory": 244.0
   },
   {
     "family": "Storage optimized",
     "enhanced_networking": true,
     "vCPU": 4,
-    "storage": {
-      "ssd": false,
-      "devices": 3,
-      "size": 2000
-    },
     "generation": "current",
-    "ebs_optimized": true,
     "ebs_iops": 6000,
     "network_performance": "Moderate",
     "ebs_throughput": 750,
-    "instance_type": "d2.xlarge",
-    "ECU": 14.0,
     "pricing": {
       "us-east-1": {
         "mswin": "0.821",
@@ -3454,30 +3556,31 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
-    "memory": 30.5,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": {
+      "ssd": false,
+      "devices": 3,
+      "size": 2000
+    },
+    "max_bandwidth": 93.75,
+    "instance_type": "d2.xlarge",
+    "ECU": 14.0,
+    "memory": 30.5
   },
   {
     "family": "Storage optimized",
     "enhanced_networking": true,
     "vCPU": 8,
-    "storage": {
-      "ssd": false,
-      "devices": 6,
-      "size": 2000
-    },
     "generation": "current",
-    "ebs_optimized": true,
     "ebs_iops": 8000,
     "network_performance": "High",
     "ebs_throughput": 1000,
-    "instance_type": "d2.2xlarge",
-    "ECU": 28.0,
     "pricing": {
       "us-east-1": {
         "mswin": "1.601",
@@ -3512,30 +3615,31 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
-    "memory": 61.0,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": {
+      "ssd": false,
+      "devices": 6,
+      "size": 2000
+    },
+    "max_bandwidth": 125.0,
+    "instance_type": "d2.2xlarge",
+    "ECU": 28.0,
+    "memory": 61.0
   },
   {
     "family": "Storage optimized",
     "enhanced_networking": true,
     "vCPU": 16,
-    "storage": {
-      "ssd": false,
-      "devices": 12,
-      "size": 2000
-    },
     "generation": "current",
-    "ebs_optimized": true,
     "ebs_iops": 16000,
     "network_performance": "High",
     "ebs_throughput": 2000,
-    "instance_type": "d2.4xlarge",
-    "ECU": 56.0,
     "pricing": {
       "us-east-1": {
         "mswin": "3.062",
@@ -3570,30 +3674,31 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
-    "memory": 122.0,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": {
+      "ssd": false,
+      "devices": 12,
+      "size": 2000
+    },
+    "max_bandwidth": 250.0,
+    "instance_type": "d2.4xlarge",
+    "ECU": 56.0,
+    "memory": 122.0
   },
   {
     "family": "Storage optimized",
     "enhanced_networking": true,
     "vCPU": 36,
-    "storage": {
-      "ssd": false,
-      "devices": 24,
-      "size": 2000
-    },
     "generation": "current",
-    "ebs_optimized": true,
     "ebs_iops": 32000,
     "network_performance": "10 Gigabit",
     "ebs_throughput": 4000,
-    "instance_type": "d2.8xlarge",
-    "ECU": 116.0,
     "pricing": {
       "us-east-1": {
         "mswin": "6.198",
@@ -3628,12 +3733,21 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
-    "memory": 244.0,
     "arch": [
       "x86_64"
     ],
     "linux_virtualization_types": [
       "HVM"
-    ]
+    ],
+    "ebs_optimized": true,
+    "storage": {
+      "ssd": false,
+      "devices": 24,
+      "size": 2000
+    },
+    "max_bandwidth": 500.0,
+    "instance_type": "d2.8xlarge",
+    "ECU": 116.0,
+    "memory": 244.0
   }
 ]


### PR DESCRIPTION
I was interested in the specific MB/s for each instance and saw it's included for the EBS optimized instances, so this PR adds those.