### PR TITLE
Support for t2.large instances

### DIFF
--- a/render.py
+++ b/render.py
@@ -63,7 +63,7 @@ def network_sort(inst):
 
 def add_cpu_detail(i):
     # special burstable instances
-    if i['instance_type'] in ('t1.micro', 't2.micro', 't2.small', 't2.medium'):
+    if i['instance_type'] in ('t1.micro', 't2.micro', 't2.small', 't2.medium', 't2.large'):
         i['burstable'] = True
         i['ECU'] = i['vCPU']  # a reasonable ECU to display
     i['ECU_per_core'] = i['ECU'] / i['vCPU']

--- a/scrape.py
+++ b/scrape.py
@@ -295,10 +295,6 @@ def add_linux_ami_info(instances):
             supported_types.append('HVM')
         if totext(r[3]) == checkmark_char:
             supported_types.append('PV')
-        # G2 instances are special. Maybe we want a separate flag here in the
-        # future? Let's see how AWS evolves...
-        if totext(r[5]) == checkmark_char:
-            supported_types.append('HVM (Graphics)')
 
         # Apply types for this instance family to all matching instances
         for i in instances:

--- a/www/index.html
+++ b/www/index.html
@@ -163,7 +163,7 @@
             No
           </td>
           <td class="linux-virtualization">
-            PV
+            Unknown
           </td>
           <td class="cost cost-linux" data-pricing='{&#34;us-east-1&#34;: &#34;0.044&#34;, &#34;ap-northeast-1&#34;: &#34;0.061&#34;, &#34;sa-east-1&#34;: &#34;0.058&#34;, &#34;ap-southeast-1&#34;: &#34;0.058&#34;, &#34;ap-southeast-2&#34;: &#34;0.058&#34;, &#34;us-west-2&#34;: &#34;0.044&#34;, &#34;us-gov-west-1&#34;: &#34;0.053&#34;, &#34;us-west-1&#34;: &#34;0.047&#34;, &#34;eu-west-1&#34;: &#34;0.047&#34;}'>
                  $0.044 per hour
@@ -228,7 +228,7 @@
             No
           </td>
           <td class="linux-virtualization">
-            PV
+            Unknown
           </td>
           <td class="cost cost-linux" data-pricing='{&#34;us-east-1&#34;: &#34;0.087&#34;, &#34;ap-northeast-1&#34;: &#34;0.122&#34;, &#34;sa-east-1&#34;: &#34;0.117&#34;, &#34;ap-southeast-1&#34;: &#34;0.117&#34;, &#34;ap-southeast-2&#34;: &#34;0.117&#34;, &#34;us-west-2&#34;: &#34;0.087&#34;, &#34;us-gov-west-1&#34;: &#34;0.106&#34;, &#34;us-west-1&#34;: &#34;0.095&#34;, &#34;eu-west-1&#34;: &#34;0.095&#34;}'>
                  $0.087 per hour
@@ -295,7 +295,7 @@
             No
           </td>
           <td class="linux-virtualization">
-            PV
+            Unknown
           </td>
           <td class="cost cost-linux" data-pricing='{&#34;us-east-1&#34;: &#34;0.175&#34;, &#34;ap-northeast-1&#34;: &#34;0.243&#34;, &#34;sa-east-1&#34;: &#34;0.233&#34;, &#34;ap-southeast-1&#34;: &#34;0.233&#34;, &#34;ap-southeast-2&#34;: &#34;0.233&#34;, &#34;us-west-2&#34;: &#34;0.175&#34;, &#34;us-gov-west-1&#34;: &#34;0.211&#34;, &#34;us-west-1&#34;: &#34;0.190&#34;, &#34;eu-west-1&#34;: &#34;0.190&#34;}'>
                  $0.175 per hour
@@ -362,7 +362,7 @@
             No
           </td>
           <td class="linux-virtualization">
-            PV
+            Unknown
           </td>
           <td class="cost cost-linux" data-pricing='{&#34;us-east-1&#34;: &#34;0.350&#34;, &#34;ap-northeast-1&#34;: &#34;0.486&#34;, &#34;sa-east-1&#34;: &#34;0.467&#34;, &#34;ap-southeast-1&#34;: &#34;0.467&#34;, &#34;ap-southeast-2&#34;: &#34;0.467&#34;, &#34;us-west-2&#34;: &#34;0.350&#34;, &#34;us-gov-west-1&#34;: &#34;0.423&#34;, &#34;us-west-1&#34;: &#34;0.379&#34;, &#34;eu-west-1&#34;: &#34;0.379&#34;}'>
                  $0.350 per hour
@@ -427,7 +427,7 @@
             No
           </td>
           <td class="linux-virtualization">
-            PV
+            Unknown
           </td>
           <td class="cost cost-linux" data-pricing='{&#34;us-east-1&#34;: &#34;0.130&#34;, &#34;ap-northeast-1&#34;: &#34;0.158&#34;, &#34;sa-east-1&#34;: &#34;0.179&#34;, &#34;ap-southeast-1&#34;: &#34;0.164&#34;, &#34;ap-southeast-2&#34;: &#34;0.164&#34;, &#34;us-west-2&#34;: &#34;0.130&#34;, &#34;us-gov-west-1&#34;: &#34;0.157&#34;, &#34;us-west-1&#34;: &#34;0.148&#34;, &#34;eu-west-1&#34;: &#34;0.148&#34;}'>
                  $0.130 per hour
@@ -438,7 +438,7 @@
           <td class="cost cost-mswinSQLWeb" data-pricing='{&#34;us-east-1&#34;: &#34;0.310&#34;, &#34;ap-northeast-1&#34;: &#34;0.310&#34;, &#34;sa-east-1&#34;: &#34;0.369&#34;, &#34;ap-southeast-1&#34;: &#34;0.310&#34;, &#34;ap-southeast-2&#34;: &#34;0.310&#34;, &#34;us-west-2&#34;: &#34;0.310&#34;, &#34;us-gov-west-1&#34;: &#34;0.366&#34;, &#34;us-west-1&#34;: &#34;0.329&#34;, &#34;eu-west-1&#34;: &#34;0.310&#34;}'>
                  $0.310 per hour
           </td>
-          <td class="cost cost-mswinSQL" data-pricing='{&#34;us-east-1&#34;: &#34;N/A&#34;, &#34;ap-northeast-1&#34;: &#34;N/A&#34;, &#34;sa-east-1&#34;: &#34;N/A&#34;, &#34;ap-southeast-1&#34;: &#34;N/A&#34;, &#34;ap-southeast-2&#34;: &#34;N/A&#34;, &#34;us-west-2&#34;: &#34;N/A&#34;, &#34;us-gov-west-1&#34;: 0, &#34;us-west-1&#34;: &#34;N/A&#34;, &#34;eu-west-1&#34;: &#34;N/A&#34;}'>
+          <td class="cost cost-mswinSQL" data-pricing='{&#34;us-east-1&#34;: 0, &#34;ap-northeast-1&#34;: 0, &#34;sa-east-1&#34;: 0, &#34;ap-southeast-1&#34;: 0, &#34;ap-southeast-2&#34;: 0, &#34;us-west-2&#34;: 0, &#34;us-gov-west-1&#34;: 0, &#34;us-west-1&#34;: 0, &#34;eu-west-1&#34;: 0}'>
             unavailable
           </td>
         </tr>
@@ -494,7 +494,7 @@
             No
           </td>
           <td class="linux-virtualization">
-            PV
+            Unknown
           </td>
           <td class="cost cost-linux" data-pricing='{&#34;us-east-1&#34;: &#34;0.520&#34;, &#34;ap-northeast-1&#34;: &#34;0.632&#34;, &#34;sa-east-1&#34;: &#34;0.718&#34;, &#34;ap-southeast-1&#34;: &#34;0.655&#34;, &#34;ap-southeast-2&#34;: &#34;0.655&#34;, &#34;us-west-2&#34;: &#34;0.520&#34;, &#34;us-gov-west-1&#34;: &#34;0.628&#34;, &#34;us-west-1&#34;: &#34;0.592&#34;, &#34;eu-west-1&#34;: &#34;0.592&#34;}'>
                  $0.520 per hour
@@ -559,7 +559,7 @@
             No
           </td>
           <td class="linux-virtualization">
-            HVM
+            Unknown
           </td>
           <td class="cost cost-linux" data-pricing='{&#34;us-west-2&#34;: &#34;2.000&#34;, &#34;us-east-1&#34;: &#34;2.000&#34;, &#34;ap-northeast-1&#34;: &#34;2.349&#34;, &#34;us-gov-west-1&#34;: &#34;2.250&#34;, &#34;eu-west-1&#34;: &#34;2.250&#34;}'>
                  $2.000 per hour
@@ -689,7 +689,7 @@
             No
           </td>
           <td class="linux-virtualization">
-            PV
+            Unknown
           </td>
           <td class="cost cost-linux" data-pricing='{&#34;us-east-1&#34;: &#34;0.245&#34;, &#34;ap-northeast-1&#34;: &#34;0.287&#34;, &#34;sa-east-1&#34;: &#34;0.323&#34;, &#34;ap-southeast-1&#34;: &#34;0.296&#34;, &#34;ap-southeast-2&#34;: &#34;0.296&#34;, &#34;us-west-2&#34;: &#34;0.245&#34;, &#34;us-gov-west-1&#34;: &#34;0.293&#34;, &#34;us-west-1&#34;: &#34;0.275&#34;, &#34;eu-west-1&#34;: &#34;0.275&#34;}'>
                  $0.245 per hour
@@ -756,7 +756,7 @@
             No
           </td>
           <td class="linux-virtualization">
-            PV
+            Unknown
           </td>
           <td class="cost cost-linux" data-pricing='{&#34;us-east-1&#34;: &#34;0.490&#34;, &#34;ap-northeast-1&#34;: &#34;0.575&#34;, &#34;sa-east-1&#34;: &#34;0.645&#34;, &#34;ap-southeast-1&#34;: &#34;0.592&#34;, &#34;ap-southeast-2&#34;: &#34;0.592&#34;, &#34;us-west-2&#34;: &#34;0.490&#34;, &#34;us-gov-west-1&#34;: &#34;0.586&#34;, &#34;us-west-1&#34;: &#34;0.550&#34;, &#34;eu-west-1&#34;: &#34;0.550&#34;}'>
                  $0.490 per hour
@@ -823,7 +823,7 @@
             No
           </td>
           <td class="linux-virtualization">
-            PV
+            Unknown
           </td>
           <td class="cost cost-linux" data-pricing='{&#34;us-east-1&#34;: &#34;0.980&#34;, &#34;ap-northeast-1&#34;: &#34;1.150&#34;, &#34;sa-east-1&#34;: &#34;1.291&#34;, &#34;ap-southeast-1&#34;: &#34;1.183&#34;, &#34;ap-southeast-2&#34;: &#34;1.183&#34;, &#34;us-west-2&#34;: &#34;0.980&#34;, &#34;us-gov-west-1&#34;: &#34;1.171&#34;, &#34;us-west-1&#34;: &#34;1.100&#34;, &#34;eu-west-1&#34;: &#34;1.100&#34;}'>
                  $0.980 per hour
@@ -888,7 +888,7 @@
             No
           </td>
           <td class="linux-virtualization">
-            HVM
+            Unknown
           </td>
           <td class="cost cost-linux" data-pricing='{&#34;us-west-2&#34;: &#34;3.500&#34;, &#34;us-east-1&#34;: &#34;3.500&#34;, &#34;ap-northeast-1&#34;: &#34;4.105&#34;, &#34;eu-west-1&#34;: &#34;3.750&#34;}'>
                  $3.500 per hour
@@ -953,18 +953,18 @@
             No
           </td>
           <td class="linux-virtualization">
-            HVM, PV
+            Unknown
           </td>
-          <td class="cost cost-linux" data-pricing='{&#34;us-east-1&#34;: &#34;3.100&#34;, &#34;ap-northeast-1&#34;: &#34;3.276&#34;, &#34;sa-east-1&#34;: &#34;N/A&#34;, &#34;ap-southeast-1&#34;: &#34;N/A&#34;, &#34;ap-southeast-2&#34;: &#34;N/A&#34;, &#34;us-west-2&#34;: &#34;3.100&#34;, &#34;us-gov-west-1&#34;: &#34;N/A&#34;, &#34;us-west-1&#34;: &#34;N/A&#34;, &#34;eu-west-1&#34;: &#34;3.100&#34;}'>
+          <td class="cost cost-linux" data-pricing='{&#34;us-west-2&#34;: &#34;3.100&#34;, &#34;us-east-1&#34;: &#34;3.100&#34;, &#34;ap-northeast-1&#34;: &#34;3.276&#34;, &#34;eu-west-1&#34;: &#34;3.100&#34;}'>
                  $3.100 per hour
           </td>
-          <td class="cost cost-mswin" data-pricing='{&#34;us-east-1&#34;: &#34;3.580&#34;, &#34;ap-northeast-1&#34;: &#34;3.686&#34;, &#34;sa-east-1&#34;: &#34;N/A&#34;, &#34;ap-southeast-1&#34;: &#34;N/A&#34;, &#34;ap-southeast-2&#34;: &#34;N/A&#34;, &#34;us-west-2&#34;: &#34;3.580&#34;, &#34;us-gov-west-1&#34;: &#34;N/A&#34;, &#34;us-west-1&#34;: &#34;N/A&#34;, &#34;eu-west-1&#34;: &#34;3.580&#34;}'>
+          <td class="cost cost-mswin" data-pricing='{&#34;us-west-2&#34;: &#34;3.580&#34;, &#34;us-east-1&#34;: &#34;3.580&#34;, &#34;ap-northeast-1&#34;: &#34;3.686&#34;, &#34;eu-west-1&#34;: &#34;3.580&#34;}'>
                  $3.580 per hour
           </td>
-          <td class="cost cost-mswinSQLWeb" data-pricing='{&#34;us-east-1&#34;: &#34;3.660&#34;, &#34;ap-northeast-1&#34;: &#34;4.084&#34;, &#34;sa-east-1&#34;: &#34;N/A&#34;, &#34;ap-southeast-1&#34;: &#34;N/A&#34;, &#34;ap-southeast-2&#34;: &#34;N/A&#34;, &#34;us-west-2&#34;: &#34;3.660&#34;, &#34;us-gov-west-1&#34;: &#34;N/A&#34;, &#34;us-west-1&#34;: &#34;N/A&#34;, &#34;eu-west-1&#34;: &#34;3.660&#34;}'>
+          <td class="cost cost-mswinSQLWeb" data-pricing='{&#34;us-west-2&#34;: &#34;3.660&#34;, &#34;us-east-1&#34;: &#34;3.660&#34;, &#34;ap-northeast-1&#34;: &#34;4.084&#34;, &#34;eu-west-1&#34;: &#34;3.660&#34;}'>
                  $3.660 per hour
           </td>
-          <td class="cost cost-mswinSQL" data-pricing='{&#34;us-east-1&#34;: &#34;4.607&#34;, &#34;ap-northeast-1&#34;: &#34;6.829&#34;, &#34;sa-east-1&#34;: &#34;N/A&#34;, &#34;ap-southeast-1&#34;: &#34;N/A&#34;, &#34;ap-southeast-2&#34;: &#34;N/A&#34;, &#34;us-west-2&#34;: &#34;4.607&#34;, &#34;us-gov-west-1&#34;: 0, &#34;us-west-1&#34;: &#34;N/A&#34;, &#34;eu-west-1&#34;: &#34;4.607&#34;}'>
+          <td class="cost cost-mswinSQL" data-pricing='{&#34;us-west-2&#34;: &#34;4.607&#34;, &#34;us-east-1&#34;: &#34;4.607&#34;, &#34;ap-northeast-1&#34;: &#34;6.829&#34;, &#34;eu-west-1&#34;: &#34;4.607&#34;}'>
                  $4.607 per hour
           </td>
         </tr>
@@ -1018,18 +1018,18 @@
             No
           </td>
           <td class="linux-virtualization">
-            HVM, PV
+            Unknown
           </td>
-          <td class="cost cost-linux" data-pricing='{&#34;us-east-1&#34;: &#34;4.600&#34;, &#34;ap-northeast-1&#34;: &#34;5.400&#34;, &#34;sa-east-1&#34;: &#34;N/A&#34;, &#34;ap-southeast-1&#34;: &#34;5.570&#34;, &#34;ap-southeast-2&#34;: &#34;5.570&#34;, &#34;us-west-2&#34;: &#34;4.600&#34;, &#34;us-gov-west-1&#34;: &#34;5.520&#34;, &#34;us-west-1&#34;: &#34;N/A&#34;, &#34;eu-west-1&#34;: &#34;4.900&#34;}'>
+          <td class="cost cost-linux" data-pricing='{&#34;us-east-1&#34;: &#34;4.600&#34;, &#34;ap-northeast-1&#34;: &#34;5.400&#34;, &#34;ap-southeast-1&#34;: &#34;5.570&#34;, &#34;ap-southeast-2&#34;: &#34;5.570&#34;, &#34;us-west-2&#34;: &#34;4.600&#34;, &#34;us-gov-west-1&#34;: &#34;5.520&#34;, &#34;eu-west-1&#34;: &#34;4.900&#34;}'>
                  $4.600 per hour
           </td>
-          <td class="cost cost-mswin" data-pricing='{&#34;us-east-1&#34;: &#34;4.931&#34;, &#34;ap-northeast-1&#34;: &#34;5.714&#34;, &#34;sa-east-1&#34;: &#34;N/A&#34;, &#34;ap-southeast-1&#34;: &#34;5.901&#34;, &#34;ap-southeast-2&#34;: &#34;5.901&#34;, &#34;us-west-2&#34;: &#34;4.931&#34;, &#34;us-gov-west-1&#34;: &#34;6.126&#34;, &#34;us-west-1&#34;: &#34;N/A&#34;, &#34;eu-west-1&#34;: &#34;4.931&#34;}'>
+          <td class="cost cost-mswin" data-pricing='{&#34;us-east-1&#34;: &#34;4.931&#34;, &#34;ap-northeast-1&#34;: &#34;5.714&#34;, &#34;ap-southeast-1&#34;: &#34;5.901&#34;, &#34;ap-southeast-2&#34;: &#34;5.901&#34;, &#34;us-west-2&#34;: &#34;4.931&#34;, &#34;us-gov-west-1&#34;: &#34;6.126&#34;, &#34;eu-west-1&#34;: &#34;4.931&#34;}'>
                  $4.931 per hour
           </td>
-          <td class="cost cost-mswinSQLWeb" data-pricing='{&#34;us-east-1&#34;: &#34;5.144&#34;, &#34;ap-northeast-1&#34;: &#34;5.917&#34;, &#34;sa-east-1&#34;: &#34;N/A&#34;, &#34;ap-southeast-1&#34;: &#34;6.114&#34;, &#34;ap-southeast-2&#34;: &#34;6.114&#34;, &#34;us-west-2&#34;: &#34;5.144&#34;, &#34;us-gov-west-1&#34;: &#34;6.339&#34;, &#34;us-west-1&#34;: &#34;N/A&#34;, &#34;eu-west-1&#34;: &#34;5.144&#34;}'>
+          <td class="cost cost-mswinSQLWeb" data-pricing='{&#34;us-east-1&#34;: &#34;5.144&#34;, &#34;ap-northeast-1&#34;: &#34;5.917&#34;, &#34;ap-southeast-1&#34;: &#34;6.114&#34;, &#34;ap-southeast-2&#34;: &#34;6.114&#34;, &#34;us-west-2&#34;: &#34;5.144&#34;, &#34;us-gov-west-1&#34;: &#34;6.339&#34;, &#34;eu-west-1&#34;: &#34;5.144&#34;}'>
                  $5.144 per hour
           </td>
-          <td class="cost cost-mswinSQL" data-pricing='{&#34;us-east-1&#34;: &#34;8.350&#34;, &#34;ap-northeast-1&#34;: &#34;8.970&#34;, &#34;sa-east-1&#34;: &#34;N/A&#34;, &#34;ap-southeast-1&#34;: &#34;9.320&#34;, &#34;ap-southeast-2&#34;: &#34;9.320&#34;, &#34;us-west-2&#34;: &#34;8.350&#34;, &#34;us-gov-west-1&#34;: 0, &#34;us-west-1&#34;: &#34;N/A&#34;, &#34;eu-west-1&#34;: &#34;8.350&#34;}'>
+          <td class="cost cost-mswinSQL" data-pricing='{&#34;us-east-1&#34;: &#34;8.350&#34;, &#34;ap-northeast-1&#34;: &#34;8.970&#34;, &#34;ap-southeast-1&#34;: &#34;9.320&#34;, &#34;ap-southeast-2&#34;: &#34;9.320&#34;, &#34;us-west-2&#34;: &#34;8.350&#34;, &#34;us-gov-west-1&#34;: &#34;9.270&#34;, &#34;eu-west-1&#34;: &#34;8.350&#34;}'>
                  $8.350 per hour
           </td>
         </tr>
@@ -1081,7 +1081,7 @@
             No
           </td>
           <td class="linux-virtualization">
-            PV
+            Unknown
           </td>
           <td class="cost cost-linux" data-pricing='{&#34;us-east-1&#34;: &#34;0.020&#34;, &#34;ap-northeast-1&#34;: &#34;0.026&#34;, &#34;sa-east-1&#34;: &#34;0.027&#34;, &#34;ap-southeast-1&#34;: &#34;0.020&#34;, &#34;ap-southeast-2&#34;: &#34;0.020&#34;, &#34;us-west-2&#34;: &#34;0.020&#34;, &#34;us-gov-west-1&#34;: &#34;0.024&#34;, &#34;us-west-1&#34;: &#34;0.025&#34;, &#34;eu-west-1&#34;: &#34;0.020&#34;}'>
                  $0.020 per hour
@@ -1092,7 +1092,7 @@
           <td class="cost cost-mswinSQLWeb" data-pricing='{&#34;us-east-1&#34;: &#34;0.070&#34;, &#34;ap-northeast-1&#34;: &#34;0.077&#34;, &#34;sa-east-1&#34;: &#34;0.077&#34;, &#34;ap-southeast-1&#34;: &#34;0.075&#34;, &#34;ap-southeast-2&#34;: &#34;0.075&#34;, &#34;us-west-2&#34;: &#34;0.070&#34;, &#34;us-gov-west-1&#34;: &#34;0.074&#34;, &#34;us-west-1&#34;: &#34;0.075&#34;, &#34;eu-west-1&#34;: &#34;0.075&#34;}'>
                  $0.070 per hour
           </td>
-          <td class="cost cost-mswinSQL" data-pricing='{&#34;us-east-1&#34;: &#34;N/A&#34;, &#34;ap-northeast-1&#34;: &#34;N/A&#34;, &#34;sa-east-1&#34;: &#34;N/A&#34;, &#34;ap-southeast-1&#34;: &#34;N/A&#34;, &#34;ap-southeast-2&#34;: &#34;N/A&#34;, &#34;us-west-2&#34;: &#34;N/A&#34;, &#34;us-gov-west-1&#34;: 0, &#34;us-west-1&#34;: &#34;N/A&#34;, &#34;eu-west-1&#34;: &#34;N/A&#34;}'>
+          <td class="cost cost-mswinSQL" data-pricing='{&#34;us-east-1&#34;: 0, &#34;ap-northeast-1&#34;: 0, &#34;sa-east-1&#34;: 0, &#34;ap-southeast-1&#34;: 0, &#34;ap-southeast-2&#34;: 0, &#34;us-west-2&#34;: 0, &#34;us-gov-west-1&#34;: 0, &#34;us-west-1&#34;: 0, &#34;eu-west-1&#34;: 0}'>
             unavailable
           </td>
         </tr>
@@ -1280,6 +1280,69 @@
           </td>
           <td class="cost cost-mswinSQLWeb" data-pricing='{&#34;us-east-1&#34;: &#34;0.272&#34;, &#34;ap-northeast-1&#34;: &#34;0.300&#34;, &#34;sa-east-1&#34;: &#34;0.328&#34;, &#34;ap-southeast-1&#34;: &#34;0.300&#34;, &#34;ap-southeast-2&#34;: &#34;0.300&#34;, &#34;us-west-2&#34;: &#34;0.272&#34;, &#34;us-gov-west-1&#34;: &#34;0.282&#34;, &#34;us-west-1&#34;: &#34;0.288&#34;, &#34;eu-central-1&#34;: &#34;0.280&#34;, &#34;eu-west-1&#34;: &#34;0.276&#34;}'>
                  $0.272 per hour
+          </td>
+          <td class="cost cost-mswinSQL" data-pricing='{&#34;us-east-1&#34;: 0, &#34;ap-northeast-1&#34;: 0, &#34;sa-east-1&#34;: 0, &#34;ap-southeast-1&#34;: 0, &#34;ap-southeast-2&#34;: 0, &#34;us-west-2&#34;: 0, &#34;us-gov-west-1&#34;: 0, &#34;us-west-1&#34;: 0, &#34;eu-central-1&#34;: 0, &#34;eu-west-1&#34;: 0}'>
+            unavailable
+          </td>
+        </tr>
+        <tr class='instance' id="t2.large">
+          <td class="name">T2 Large</td>
+          <td class="apiname">t2.large</td>
+          <td class="memory"><span sort="8.0">8.0 GB</span></td>
+          <td class="computeunits">
+            <span sort="2">2 units</span>
+             (<a href="http://aws.amazon.com/ec2/instance-types/#burst" target="_blank">Burstable</a>)
+          </td>
+          <td class="cores">
+            <span sort="2">
+              2 cores
+            </span>
+          </td>
+          <td class="ecu-per-core">
+            <span sort="1">1 units</span>
+          </td>
+          <td class="storage">
+            
+            <span sort="0">0 GB (EBS only)</span>
+          </td>
+          <td class="architecture">
+            64-bit
+          </td>
+          <td class="networkperf">
+            <span sort="4">
+              Low to Moderate
+            </span>
+          </td>
+          <td class="max_bandwidth">
+            <span sort="0">N/A</span>
+          </td>
+          <td class="ebs-throughput">
+            <span sort="0">
+              0
+            </span>
+          </td>
+          <td class="ebs-iops">
+            <span sort="0">
+              0
+            </span>
+          </td>
+          <td class="maxips">
+              36
+          </td>
+          <td class="enhanced-networking">
+            No
+          </td>
+          <td class="linux-virtualization">
+            HVM
+          </td>
+          <td class="cost cost-linux" data-pricing='{&#34;us-east-1&#34;: &#34;0.104&#34;, &#34;ap-northeast-1&#34;: &#34;0.160&#34;, &#34;sa-east-1&#34;: &#34;0.216&#34;, &#34;ap-southeast-1&#34;: &#34;0.160&#34;, &#34;ap-southeast-2&#34;: &#34;0.160&#34;, &#34;us-west-2&#34;: &#34;0.104&#34;, &#34;us-gov-west-1&#34;: &#34;0.124&#34;, &#34;us-west-1&#34;: &#34;0.136&#34;, &#34;eu-central-1&#34;: &#34;0.120&#34;, &#34;eu-west-1&#34;: &#34;0.112&#34;}'>
+                 $0.104 per hour
+          </td>
+          <td class="cost cost-mswin" data-pricing='{&#34;us-east-1&#34;: &#34;0.134&#34;, &#34;ap-northeast-1&#34;: &#34;0.190&#34;, &#34;sa-east-1&#34;: &#34;0.246&#34;, &#34;ap-southeast-1&#34;: &#34;0.190&#34;, &#34;ap-southeast-2&#34;: &#34;0.190&#34;, &#34;us-west-2&#34;: &#34;0.134&#34;, &#34;us-gov-west-1&#34;: &#34;0.154&#34;, &#34;us-west-1&#34;: &#34;0.166&#34;, &#34;eu-central-1&#34;: &#34;0.150&#34;, &#34;eu-west-1&#34;: &#34;0.142&#34;}'>
+                 $0.134 per hour
+          </td>
+          <td class="cost cost-mswinSQLWeb" data-pricing='{&#34;us-east-1&#34;: &#34;0.434&#34;, &#34;ap-northeast-1&#34;: &#34;0.490&#34;, &#34;sa-east-1&#34;: &#34;0.546&#34;, &#34;ap-southeast-1&#34;: &#34;0.490&#34;, &#34;ap-southeast-2&#34;: &#34;0.490&#34;, &#34;us-west-2&#34;: &#34;0.434&#34;, &#34;us-gov-west-1&#34;: &#34;0.454&#34;, &#34;us-west-1&#34;: &#34;0.466&#34;, &#34;eu-central-1&#34;: &#34;0.450&#34;, &#34;eu-west-1&#34;: &#34;0.442&#34;}'>
+                 $0.434 per hour
           </td>
           <td class="cost cost-mswinSQL" data-pricing='{&#34;us-east-1&#34;: 0, &#34;ap-northeast-1&#34;: 0, &#34;sa-east-1&#34;: 0, &#34;ap-southeast-1&#34;: 0, &#34;ap-southeast-2&#34;: 0, &#34;us-west-2&#34;: 0, &#34;us-gov-west-1&#34;: 0, &#34;us-west-1&#34;: 0, &#34;eu-central-1&#34;: 0, &#34;eu-west-1&#34;: 0}'>
             unavailable
@@ -2572,7 +2635,7 @@
             No
           </td>
           <td class="linux-virtualization">
-            HVM (Graphics)
+            HVM
           </td>
           <td class="cost cost-linux" data-pricing='{&#34;us-east-1&#34;: &#34;0.650&#34;, &#34;ap-northeast-1&#34;: &#34;0.898&#34;, &#34;ap-southeast-1&#34;: &#34;1.000&#34;, &#34;ap-southeast-2&#34;: &#34;0.898&#34;, &#34;us-west-2&#34;: &#34;0.650&#34;, &#34;us-west-1&#34;: &#34;0.702&#34;, &#34;eu-central-1&#34;: &#34;0.772&#34;, &#34;eu-west-1&#34;: &#34;0.702&#34;}'>
                  $0.650 per hour
@@ -2637,7 +2700,7 @@
             No
           </td>
           <td class="linux-virtualization">
-            HVM (Graphics)
+            HVM
           </td>
           <td class="cost cost-linux" data-pricing='{&#34;us-east-1&#34;: &#34;2.600&#34;, &#34;ap-northeast-1&#34;: &#34;3.592&#34;, &#34;ap-southeast-1&#34;: &#34;4.000&#34;, &#34;ap-southeast-2&#34;: &#34;3.592&#34;, &#34;us-west-2&#34;: &#34;2.600&#34;, &#34;us-west-1&#34;: &#34;2.808&#34;, &#34;eu-central-1&#34;: &#34;3.088&#34;, &#34;eu-west-1&#34;: &#34;2.808&#34;}'>
                  $2.600 per hour
@@ -3525,7 +3588,7 @@
       <p>It was started by <a href="http://twitter.com/powdahound" target="_blank">@powdahound</a>, contributed to by <a href="https://github.com/powdahound/ec2instances.info/contributors" target="_blank">many</a>, is <a href="http://powdahound.com/2011/03/hosting-a-static-site-on-amazon-s3-ec2instances-info" target="_blank">hosted on S3</a>, and awaits your improvements <a href="https://github.com/powdahound/ec2instances.info" target="_blank">on GitHub</a>.</p>
     </div>
     <div class="well-small">
-      <p class="small">Generated at: 2015-06-13 01:56:08 UTC</p>
+      <p class="small">Generated at: 2015-06-17 14:06:39 UTC</p>
     </div>
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript" charset="utf-8"></script>

--- a/www/instances.json
+++ b/www/instances.json
@@ -71,9 +71,7 @@
       "i386",
       "x86_64"
     ],
-    "linux_virtualization_types": [
-      "PV"
-    ],
+    "linux_virtualization_types": [],
     "ebs_optimized": false,
     "storage": {
       "ssd": false,
@@ -157,9 +155,7 @@
       "i386",
       "x86_64"
     ],
-    "linux_virtualization_types": [
-      "PV"
-    ],
+    "linux_virtualization_types": [],
     "ebs_optimized": false,
     "storage": {
       "ssd": false,
@@ -242,9 +238,7 @@
     "arch": [
       "x86_64"
     ],
-    "linux_virtualization_types": [
-      "PV"
-    ],
+    "linux_virtualization_types": [],
     "ebs_optimized": true,
     "storage": {
       "ssd": false,
@@ -327,9 +321,7 @@
     "arch": [
       "x86_64"
     ],
-    "linux_virtualization_types": [
-      "PV"
-    ],
+    "linux_virtualization_types": [],
     "ebs_optimized": true,
     "storage": {
       "ssd": false,
@@ -352,37 +344,31 @@
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "0.310",
-        "mswinSQL": "N/A",
         "mswin": "0.210",
         "linux": "0.130"
       },
       "ap-northeast-1": {
         "mswinSQLWeb": "0.310",
-        "mswinSQL": "N/A",
         "mswin": "0.258",
         "linux": "0.158"
       },
       "sa-east-1": {
         "mswinSQLWeb": "0.369",
-        "mswinSQL": "N/A",
         "mswin": "0.259",
         "linux": "0.179"
       },
       "ap-southeast-1": {
         "mswinSQLWeb": "0.310",
-        "mswinSQL": "N/A",
         "mswin": "0.266",
         "linux": "0.164"
       },
       "ap-southeast-2": {
         "mswinSQLWeb": "0.310",
-        "mswinSQL": "N/A",
         "mswin": "0.266",
         "linux": "0.164"
       },
       "us-west-2": {
         "mswinSQLWeb": "0.310",
-        "mswinSQL": "N/A",
         "mswin": "0.210",
         "linux": "0.130"
       },
@@ -393,13 +379,11 @@
       },
       "us-west-1": {
         "mswinSQLWeb": "0.329",
-        "mswinSQL": "N/A",
         "mswin": "0.228",
         "linux": "0.148"
       },
       "eu-west-1": {
         "mswinSQLWeb": "0.310",
-        "mswinSQL": "N/A",
         "mswin": "0.210",
         "linux": "0.148"
       }
@@ -412,9 +396,7 @@
       "i386",
       "x86_64"
     ],
-    "linux_virtualization_types": [
-      "PV"
-    ],
+    "linux_virtualization_types": [],
     "ebs_optimized": false,
     "storage": {
       "ssd": false,
@@ -497,9 +479,7 @@
     "arch": [
       "x86_64"
     ],
-    "linux_virtualization_types": [
-      "PV"
-    ],
+    "linux_virtualization_types": [],
     "ebs_optimized": true,
     "storage": {
       "ssd": false,
@@ -558,9 +538,7 @@
     "arch": [
       "x86_64"
     ],
-    "linux_virtualization_types": [
-      "HVM"
-    ],
+    "linux_virtualization_types": [],
     "ebs_optimized": false,
     "storage": {
       "ssd": false,
@@ -684,9 +662,7 @@
     "arch": [
       "x86_64"
     ],
-    "linux_virtualization_types": [
-      "PV"
-    ],
+    "linux_virtualization_types": [],
     "ebs_optimized": false,
     "storage": {
       "ssd": false,
@@ -769,9 +745,7 @@
     "arch": [
       "x86_64"
     ],
-    "linux_virtualization_types": [
-      "PV"
-    ],
+    "linux_virtualization_types": [],
     "ebs_optimized": true,
     "storage": {
       "ssd": false,
@@ -854,9 +828,7 @@
     "arch": [
       "x86_64"
     ],
-    "linux_virtualization_types": [
-      "PV"
-    ],
+    "linux_virtualization_types": [],
     "ebs_optimized": true,
     "storage": {
       "ssd": false,
@@ -909,9 +881,7 @@
     "arch": [
       "x86_64"
     ],
-    "linux_virtualization_types": [
-      "HVM"
-    ],
+    "linux_virtualization_types": [],
     "ebs_optimized": false,
     "storage": {
       "ssd": true,
@@ -932,6 +902,12 @@
     "network_performance": "10 Gigabit",
     "ebs_throughput": 0,
     "pricing": {
+      "us-west-2": {
+        "mswinSQLWeb": "3.660",
+        "mswinSQL": "4.607",
+        "mswin": "3.580",
+        "linux": "3.100"
+      },
       "us-east-1": {
         "mswinSQLWeb": "3.660",
         "mswinSQL": "4.607",
@@ -943,41 +919,6 @@
         "mswinSQL": "6.829",
         "mswin": "3.686",
         "linux": "3.276"
-      },
-      "sa-east-1": {
-        "mswinSQLWeb": "N/A",
-        "mswinSQL": "N/A",
-        "mswin": "N/A",
-        "linux": "N/A"
-      },
-      "ap-southeast-1": {
-        "mswinSQLWeb": "N/A",
-        "mswinSQL": "N/A",
-        "mswin": "N/A",
-        "linux": "N/A"
-      },
-      "ap-southeast-2": {
-        "mswinSQLWeb": "N/A",
-        "mswinSQL": "N/A",
-        "mswin": "N/A",
-        "linux": "N/A"
-      },
-      "us-west-2": {
-        "mswinSQLWeb": "3.660",
-        "mswinSQL": "4.607",
-        "mswin": "3.580",
-        "linux": "3.100"
-      },
-      "us-gov-west-1": {
-        "mswinSQLWeb": "N/A",
-        "mswin": "N/A",
-        "linux": "N/A"
-      },
-      "us-west-1": {
-        "mswinSQLWeb": "N/A",
-        "mswinSQL": "N/A",
-        "mswin": "N/A",
-        "linux": "N/A"
       },
       "eu-west-1": {
         "mswinSQLWeb": "3.660",
@@ -993,10 +934,7 @@
     "arch": [
       "x86_64"
     ],
-    "linux_virtualization_types": [
-      "HVM",
-      "PV"
-    ],
+    "linux_virtualization_types": [],
     "ebs_optimized": false,
     "storage": {
       "ssd": true,
@@ -1029,12 +967,6 @@
         "mswin": "5.714",
         "linux": "5.400"
       },
-      "sa-east-1": {
-        "mswinSQLWeb": "N/A",
-        "mswinSQL": "N/A",
-        "mswin": "N/A",
-        "linux": "N/A"
-      },
       "ap-southeast-1": {
         "mswinSQLWeb": "6.114",
         "mswinSQL": "9.320",
@@ -1055,14 +987,9 @@
       },
       "us-gov-west-1": {
         "mswinSQLWeb": "6.339",
+        "mswinSQL": "9.270",
         "mswin": "6.126",
         "linux": "5.520"
-      },
-      "us-west-1": {
-        "mswinSQLWeb": "N/A",
-        "mswinSQL": "N/A",
-        "mswin": "N/A",
-        "linux": "N/A"
       },
       "eu-west-1": {
         "mswinSQLWeb": "5.144",
@@ -1078,10 +1005,7 @@
     "arch": [
       "x86_64"
     ],
-    "linux_virtualization_types": [
-      "HVM",
-      "PV"
-    ],
+    "linux_virtualization_types": [],
     "ebs_optimized": false,
     "storage": {
       "ssd": false,
@@ -1104,37 +1028,31 @@
     "pricing": {
       "us-east-1": {
         "mswinSQLWeb": "0.070",
-        "mswinSQL": "N/A",
         "mswin": "0.020",
         "linux": "0.020"
       },
       "ap-northeast-1": {
         "mswinSQLWeb": "0.077",
-        "mswinSQL": "N/A",
         "mswin": "0.033",
         "linux": "0.026"
       },
       "sa-east-1": {
         "mswinSQLWeb": "0.077",
-        "mswinSQL": "N/A",
         "mswin": "0.037",
         "linux": "0.027"
       },
       "ap-southeast-1": {
         "mswinSQLWeb": "0.075",
-        "mswinSQL": "N/A",
         "mswin": "0.020",
         "linux": "0.020"
       },
       "ap-southeast-2": {
         "mswinSQLWeb": "0.075",
-        "mswinSQL": "N/A",
         "mswin": "0.020",
         "linux": "0.020"
       },
       "us-west-2": {
         "mswinSQLWeb": "0.070",
-        "mswinSQL": "N/A",
         "mswin": "0.020",
         "linux": "0.020"
       },
@@ -1145,13 +1063,11 @@
       },
       "us-west-1": {
         "mswinSQLWeb": "0.075",
-        "mswinSQL": "N/A",
         "mswin": "0.035",
         "linux": "0.025"
       },
       "eu-west-1": {
         "mswinSQLWeb": "0.075",
-        "mswinSQL": "N/A",
         "mswin": "0.020",
         "linux": "0.020"
       }
@@ -1164,9 +1080,7 @@
       "i386",
       "x86_64"
     ],
-    "linux_virtualization_types": [
-      "PV"
-    ],
+    "linux_virtualization_types": [],
     "ebs_optimized": false,
     "storage": null,
     "max_bandwidth": 0,
@@ -1406,6 +1320,83 @@
     "instance_type": "t2.medium",
     "ECU": 0,
     "memory": 4.0
+  },
+  {
+    "family": "General purpose",
+    "enhanced_networking": false,
+    "vCPU": 2,
+    "generation": "current",
+    "ebs_iops": 0,
+    "network_performance": "Low to Moderate",
+    "ebs_throughput": 0,
+    "pricing": {
+      "us-east-1": {
+        "mswinSQLWeb": "0.434",
+        "mswin": "0.134",
+        "linux": "0.104"
+      },
+      "ap-northeast-1": {
+        "mswinSQLWeb": "0.490",
+        "mswin": "0.190",
+        "linux": "0.160"
+      },
+      "sa-east-1": {
+        "mswinSQLWeb": "0.546",
+        "mswin": "0.246",
+        "linux": "0.216"
+      },
+      "ap-southeast-1": {
+        "mswinSQLWeb": "0.490",
+        "mswin": "0.190",
+        "linux": "0.160"
+      },
+      "ap-southeast-2": {
+        "mswinSQLWeb": "0.490",
+        "mswin": "0.190",
+        "linux": "0.160"
+      },
+      "us-west-2": {
+        "mswinSQLWeb": "0.434",
+        "mswin": "0.134",
+        "linux": "0.104"
+      },
+      "us-gov-west-1": {
+        "mswinSQLWeb": "0.454",
+        "mswin": "0.154",
+        "linux": "0.124"
+      },
+      "us-west-1": {
+        "mswinSQLWeb": "0.466",
+        "mswin": "0.166",
+        "linux": "0.136"
+      },
+      "eu-central-1": {
+        "mswinSQLWeb": "0.450",
+        "mswin": "0.150",
+        "linux": "0.120"
+      },
+      "eu-west-1": {
+        "mswinSQLWeb": "0.442",
+        "mswin": "0.142",
+        "linux": "0.112"
+      }
+    },
+    "vpc": {
+      "ips_per_eni": 12,
+      "max_enis": 3
+    },
+    "arch": [
+      "x86_64"
+    ],
+    "linux_virtualization_types": [
+      "HVM"
+    ],
+    "ebs_optimized": false,
+    "storage": null,
+    "max_bandwidth": 0,
+    "instance_type": "t2.large",
+    "ECU": 0,
+    "memory": 8.0
   },
   {
     "family": "General purpose",
@@ -3044,7 +3035,7 @@
       "x86_64"
     ],
     "linux_virtualization_types": [
-      "HVM (Graphics)"
+      "HVM"
     ],
     "ebs_optimized": true,
     "storage": {
@@ -3107,7 +3098,7 @@
       "x86_64"
     ],
     "linux_virtualization_types": [
-      "HVM (Graphics)"
+      "HVM"
     ],
     "ebs_optimized": false,
     "storage": {


### PR DESCRIPTION
Updates to include the new `t2.large` instance type.

The [Instance Type Matrix for Amazon Linux AMIs](http://aws.amazon.com/amazon-linux-ami/instance-type-matrix/) has changed:
* No longer includes a 5th column specifying `HVM (Graphics)` type instances.
* No longer includes data for some previous generation instance classes: `m1`, `c1`, `cc2`, `cg1`, `m2`, `cr1`, `hi1`,  `hs1`, `t1`.

This means that the `g2` type instances now show `HVM` for their `Linux Virtualization` column, and the above listed types now show `Unknown`, which we already show for `cg1.4xlarge` (I assume for the same reasons).

Since there is already a precedent for `cg1.4xlarge` showing `Unknown`, and these are all legacy instance types I think we are OK to not worry about adding manual support to retain their virtualization type. 