### PR TITLE
Add row filtering by min value.

### DIFF
--- a/in/index.html.mako
+++ b/in/index.html.mako
@@ -85,6 +85,20 @@
       </div>
 
     </div>
+    <div style="clear:both; float:left">
+        <strong> Filter:</strong>
+        Min Memory (GB): <input data-action="datafilter"
+                                data-type="memory"
+                                size=4 />
+
+        Compute Units: <input data-action="datafilter"
+                              data-type="computeunits"
+                              size=4 />
+
+        Storage (GB): <input data-action="datafilter"
+                             data-type="storage"
+                             size=4 />
+    </div>
 
     <table cellspacing="0" class="table table-bordered table-hover table-condensed" id="data">
       <thead>

--- a/www/default.js
+++ b/www/default.js
@@ -52,6 +52,7 @@ $(document).ready(function() {
   init_data_table();
 });
 
+
 function change_cost(duration) {
   // update menu text
   var first = duration.charAt(0).toUpperCase();
@@ -182,8 +183,32 @@ function on_data_table_initialized() {
     }
   }
 
+  // Allow row highlighting by clicking.
   $('#data tbody tr').click(function() {
     $(this).toggleClass('highlight')
+  });
+
+  // Allow row filtering by min-value match.
+  $('[data-action=datafilter]').on('keyup', function() {
+      var all_filters = $('[data-action="datafilter"]');
+      var data_rows = $('#data tr:has(td)');
+
+      data_rows.show();
+
+      all_filters.each(function() {
+          var filter_on = $(this).data('type');
+          var filter_val = parseFloat($(this).val()) || 0;
+
+          var match_fail = data_rows.filter(function() {
+              var row_val;
+              row_val = parseFloat(
+                  $(this).find('td[class~="' + filter_on + '"] span').attr('sort')
+              );
+              return row_val < filter_val;
+          });
+
+          match_fail.hide();
+      });
   });
 
   $('#url-button').click(function() {

--- a/www/index.html
+++ b/www/index.html
@@ -83,6 +83,20 @@
       </div>
 
     </div>
+    <div style="clear:both; float:left">
+        <strong> Filter:</strong>
+        Min Memory (GB): <input data-action="datafilter"
+                                data-type="memory"
+                                size=4 />
+
+        Compute Units: <input data-action="datafilter"
+                              data-type="computeunits"
+                              size=4 />
+
+        Storage (GB): <input data-action="datafilter"
+                             data-type="storage"
+                             size=4 />
+    </div>
 
     <table cellspacing="0" class="table table-bordered table-hover table-condensed" id="data">
       <thead>


### PR DESCRIPTION
"Search" allows regex compare. New filter allows multiple values
filtering such as specifying the minimum memory needed, and min ECU.

This does not impact sorting, so you can pick your min requirements and find the cheapest instance type.

![image](https://cloud.githubusercontent.com/assets/3210918/8221680/21059a50-1516-11e5-9de2-e25eff37e66d.png)
