### PR TITLE
scrape: fix instance family queries

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -123,11 +123,11 @@ def _rindex_family(inst2family, details):
 def scrape_families():
     inst2family = dict()
     tree = etree.parse(urllib2.urlopen("http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html"), etree.HTMLParser())
-    details = tree.xpath('//table')[3]
+    details = tree.xpath('//table')[2]
     hdrs = details.xpath('thead/tr')[0]
     if totext(hdrs[0]).lower() == 'instance family' and 'current generation' in totext(hdrs[1]).lower():
        _rindex_family(inst2family, details)
-    details = tree.xpath('//table')[4]
+    details = tree.xpath('//table')[3]
     hdrs = details.xpath('thead/tr')[0]
     if totext(hdrs[0]).lower() == 'instance family' and 'previous generation' in totext(hdrs[1]).lower():
        _rindex_family(inst2family, details)


### PR DESCRIPTION
The indexes for the family tables were off-by-one, likely due to a recent update to the page.