### PR TITLE
More manual virtualisation data

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -387,7 +387,10 @@ def add_linux_ami_info(instances):
     # Adding "manual" info about older generations
     for i in instances:
         i_family_id = i.instance_type.split('.')[0]
-        if i_family_id in ('t1', 'm1', 'm2', 'c1'):
+        if i_family_id in ('cc2', 'cg1', 'hi1', 'hs1'):
+            if not 'HVM' in i.linux_virtualization_types:
+                i.linux_virtualization_types.append('HVM')
+        if i_family_id in ('t1', 'm1', 'm2', 'c1', 'hi1', 'hs1'):
             if not 'PV' in i.linux_virtualization_types:
                 i.linux_virtualization_types.append('PV')
 


### PR DESCRIPTION
Dug up some information around the instance types where Linux Virtualization currently shows "Unknown". Unfortunately I wasn't able to find anything specific on cr1. Sources below.

### cc2
https://aws.amazon.com/blogs/aws/next-generation-cluster-computing-on-amazon-ec2-the-cc2-instance-type/
> This instance type uses hardware-assisted virtualization (HVM), so you’ll need to choose an AMI accordingly.

### cg1
http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using_cluster_computing.html
> You can launch CG1 and G2 instances using any HVM AMI.

### hi1
http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/storage_instances.html
> Using **Linux paravirtual (PV) AMIs**, HI1 instances can deliver more than 120,000 4 KB random read IOPS and between 10,000 and 85,000 4 KB random write IOPS (depending on active logical block addressing span) to applications across two SSD data volumes. **Using hardware virtual machine (HVM) AMIs**, performance is approximately 90,000 4 KB random read IOPS and between 9,000 and 75,000 4 KB random write IOPS.

### hs1
http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/high_storage_instances.html
> HS1 instances support both paravirtual (PV) and hardware virtual machine (HVM) AMIs.