### PR TITLE
Make table headers wrap text

### DIFF
--- a/www/default.css
+++ b/www/default.css
@@ -42,12 +42,14 @@ body {
   background-color: #D3FFFF;
 }
 
-#data th, #data td {
+#data td {
   white-space: nowrap;
 }
 
 #data th {
   background-color: #eee;
+  word-wrap: break-word;
+
 }
 
 #data td {

--- a/www/index.html
+++ b/www/index.html
@@ -21,7 +21,7 @@
     <h1>EC2Instances.info <small>Easy Amazon EC2 Instance Comparison</small></h1>
     
 
-      <p class="pull-right label label-info">Last Update: 2016-06-29 22:31:26 UTC</p>
+      <p class="pull-right label label-info">Last Update: 2016-06-30 07:54:42 UTC</p>
       <ul class="nav nav-tabs">
         <li role="presentation" class="active"><a href="/">EC2</a></li>
         <li role="presentation" class=""><a href="/rds/">RDS</a></li>
@@ -5390,7 +5390,7 @@
       </p>
       <p>
         <strong>How?</strong>
-        Data is scraped from multiple pages on the AWS site. This was last done at 2016-06-29 22:31:26 UTC.
+        Data is scraped from multiple pages on the AWS site. This was last done at 2016-06-30 07:54:42 UTC.
       </p>
 
       <p class="bg-warning">

--- a/www/rds/index.html
+++ b/www/rds/index.html
@@ -21,7 +21,7 @@
     <h1>RDSInstances.info <small>Easy Amazon RDS Instance Comparison</small></h1>
     
 
-      <p class="pull-right label label-info">Last Update: 2016-06-29 22:31:26 UTC</p>
+      <p class="pull-right label label-info">Last Update: 2016-06-30 07:54:43 UTC</p>
       <ul class="nav nav-tabs">
         <li role="presentation" class=""><a href="/">EC2</a></li>
         <li role="presentation" class="active"><a href="/rds/">RDS</a></li>
@@ -2333,7 +2333,7 @@
       </p>
       <p>
         <strong>How?</strong>
-        Data is scraped from multiple pages on the AWS site. This was last done at 2016-06-29 22:31:26 UTC.
+        Data is scraped from multiple pages on the AWS site. This was last done at 2016-06-30 07:54:43 UTC.
       </p>
 
       <p class="bg-warning">


### PR DESCRIPTION
I'm tired of horizontal scrolling.
Added wrapping text to the table headers, now it is more compact.

Preview example:

![selection_175](https://cloud.githubusercontent.com/assets/1480252/16484005/4999a148-3eb7-11e6-8de2-932ce9b51cdb.png)