### PR TITLE
Update 'Network Performance' Rankings and Fix 'VPC Only' for p2/r4/x1

### DIFF
--- a/render.py
+++ b/render.py
@@ -13,8 +13,10 @@ def network_sort(inst):
         'Low to Moderate',
         'Moderate',
         'High',
-        '10 Gigabit'
-        ]
+        'Up to 10 Gigabit',
+        '10 Gigabit',
+        '20 Gigabit'
+    ]
     try:
         sort = network_rank.index(perf)
     except ValueError:

--- a/scrape.py
+++ b/scrape.py
@@ -416,7 +416,7 @@ def add_linux_ami_info(instances):
 def add_vpconly_detail(instances):
     # specific instances can be lanuched in VPC only
     # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-vpc.html#vpc-only-instance-types
-    vpc_only_families = ('c4', 'm4', 't2')
+    vpc_only_families = ('c4', 'm4', 'p2', 'r4', 't2', 'x1')
     for i in instances:
         for family in vpc_only_families:
             if i.instance_type.startswith(family):

--- a/scrape.py
+++ b/scrape.py
@@ -426,6 +426,7 @@ def add_vpconly_detail(instances):
 def add_pretty_names(instances):
     family_names = {
         'r3': 'R3 High-Memory',
+        'r4': 'R4 High-Memory',
         'c3': 'C3 High-CPU',
         'c4': 'C4 High-CPU',
         'm3': 'M3 General Purpose',
@@ -437,7 +438,9 @@ def add_pretty_names(instances):
         'c1' : 'C1 High-CPU',
         'hi1': 'HI1. High I/O',
         'm2' : 'M2 High Memory',
-        'm1' : 'M1 General Purpose'
+        'm1' : 'M1 General Purpose',
+        'p2' : 'General Purpose GPU',
+        'x1' : 'X1 Extra High-Memory'
         }
     for i in instances:
         pieces = i.instance_type.split('.')


### PR DESCRIPTION
This PR makes three updates:

- Add _Up to 10 Gigabit_  and _20 Gigabit_ to the ranked list so Network Performance sorts properly
- Update the VPC only instance types based on the latest information from http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-vpc.html#vpc-only-instance-types.
- Add pretty names for the p2/r4/x1 types.