### PR TITLE
IPv6 Support

### DIFF
--- a/in/index.html.mako
+++ b/in/index.html.mako
@@ -118,6 +118,7 @@
           </th>
           <th class="enhanced-networking">Enhanced Networking</th>
           <th class="vpc-only">VPC Only</th>
+          <th class="ipv6-support">IPv6 Support</th>
           <th class="linux-virtualization">Linux Virtualization</th>
 
           <th class="cost-ondemand cost-ondemand-linux">Linux On Demand cost</th>
@@ -238,6 +239,9 @@
           </td>
           <td class="vpc-only">
             ${'Yes' if inst['vpc_only'] else 'No'}
+          </td>
+          <td class="ipv6-support">
+            ${'Yes' if inst['ipv6_support'] else 'No'}
           </td>
           <td class="linux-virtualization">
             % if inst['linux_virtualization_types']:

--- a/www/index.html
+++ b/www/index.html
@@ -21,7 +21,7 @@
     <h1>EC2Instances.info <small>Easy Amazon EC2 Instance Comparison</small></h1>
     
 
-      <p class="pull-right label label-info">Last Update: 2017-01-31 11:17:36 UTC</p>
+      <p class="pull-right label label-info">Last Update: 2017-02-02 23:28:25 UTC</p>
       <ul class="nav nav-tabs">
         <li role="presentation" class="active"><a href="/">EC2</a></li>
         <li role="presentation" class=""><a href="/rds/">RDS</a></li>
@@ -29,7 +29,6 @@
     </div>
 
     <div class="clear-fix"></div>
-
     
 
 
@@ -145,6 +144,7 @@
           </th>
           <th class="enhanced-networking">Enhanced Networking</th>
           <th class="vpc-only">VPC Only</th>
+          <th class="ipv6-support">IPv6 Support</th>
           <th class="linux-virtualization">Linux Virtualization</th>
 
           <th class="cost-ondemand cost-ondemand-linux">Linux On Demand cost</th>
@@ -216,6 +216,9 @@
             No
           </td>
           <td class="vpc-only">
+            No
+          </td>
+          <td class="ipv6-support">
             No
           </td>
           <td class="linux-virtualization">
@@ -312,6 +315,9 @@
             No
           </td>
           <td class="vpc-only">
+            No
+          </td>
+          <td class="ipv6-support">
             No
           </td>
           <td class="linux-virtualization">
@@ -412,6 +418,9 @@
           <td class="vpc-only">
             No
           </td>
+          <td class="ipv6-support">
+            No
+          </td>
           <td class="linux-virtualization">
             PV
           </td>
@@ -510,6 +519,9 @@
           <td class="vpc-only">
             No
           </td>
+          <td class="ipv6-support">
+            No
+          </td>
           <td class="linux-virtualization">
             PV
           </td>
@@ -606,6 +618,9 @@
           <td class="vpc-only">
             No
           </td>
+          <td class="ipv6-support">
+            No
+          </td>
           <td class="linux-virtualization">
             PV
           </td>
@@ -698,6 +713,9 @@
             No
           </td>
           <td class="vpc-only">
+            No
+          </td>
+          <td class="ipv6-support">
             No
           </td>
           <td class="linux-virtualization">
@@ -796,6 +814,9 @@
           <td class="vpc-only">
             No
           </td>
+          <td class="ipv6-support">
+            No
+          </td>
           <td class="linux-virtualization">
             HVM
           </td>
@@ -892,6 +913,9 @@
           <td class="vpc-only">
             No
           </td>
+          <td class="ipv6-support">
+            No
+          </td>
           <td class="linux-virtualization">
             HVM
           </td>
@@ -978,6 +1002,9 @@
             No
           </td>
           <td class="vpc-only">
+            No
+          </td>
+          <td class="ipv6-support">
             No
           </td>
           <td class="linux-virtualization">
@@ -1078,6 +1105,9 @@
           <td class="vpc-only">
             No
           </td>
+          <td class="ipv6-support">
+            No
+          </td>
           <td class="linux-virtualization">
             PV
           </td>
@@ -1176,6 +1206,9 @@
           <td class="vpc-only">
             No
           </td>
+          <td class="ipv6-support">
+            No
+          </td>
           <td class="linux-virtualization">
             PV
           </td>
@@ -1270,6 +1303,9 @@
             No
           </td>
           <td class="vpc-only">
+            No
+          </td>
+          <td class="ipv6-support">
             No
           </td>
           <td class="linux-virtualization">
@@ -1368,6 +1404,9 @@
           <td class="vpc-only">
             No
           </td>
+          <td class="ipv6-support">
+            No
+          </td>
           <td class="linux-virtualization">
             HVM, PV
           </td>
@@ -1464,6 +1503,9 @@
           <td class="vpc-only">
             No
           </td>
+          <td class="ipv6-support">
+            No
+          </td>
           <td class="linux-virtualization">
             HVM, PV
           </td>
@@ -1555,6 +1597,9 @@
             No
           </td>
           <td class="vpc-only">
+            No
+          </td>
+          <td class="ipv6-support">
             No
           </td>
           <td class="linux-virtualization">
@@ -1657,6 +1702,9 @@
           <td class="vpc-only">
             Yes
           </td>
+          <td class="ipv6-support">
+            Yes
+          </td>
           <td class="linux-virtualization">
             HVM
           </td>
@@ -1751,6 +1799,9 @@
             No
           </td>
           <td class="vpc-only">
+            Yes
+          </td>
+          <td class="ipv6-support">
             Yes
           </td>
           <td class="linux-virtualization">
@@ -1853,6 +1904,9 @@
           <td class="vpc-only">
             Yes
           </td>
+          <td class="ipv6-support">
+            Yes
+          </td>
           <td class="linux-virtualization">
             HVM
           </td>
@@ -1951,6 +2005,9 @@
             No
           </td>
           <td class="vpc-only">
+            Yes
+          </td>
+          <td class="ipv6-support">
             Yes
           </td>
           <td class="linux-virtualization">
@@ -2053,6 +2110,9 @@
           <td class="vpc-only">
             Yes
           </td>
+          <td class="ipv6-support">
+            Yes
+          </td>
           <td class="linux-virtualization">
             HVM
           </td>
@@ -2151,6 +2211,9 @@
             No
           </td>
           <td class="vpc-only">
+            Yes
+          </td>
+          <td class="ipv6-support">
             Yes
           </td>
           <td class="linux-virtualization">
@@ -2253,6 +2316,9 @@
           <td class="vpc-only">
             Yes
           </td>
+          <td class="ipv6-support">
+            Yes
+          </td>
           <td class="linux-virtualization">
             HVM
           </td>
@@ -2342,6 +2408,9 @@
             Yes
           </td>
           <td class="vpc-only">
+            Yes
+          </td>
+          <td class="ipv6-support">
             Yes
           </td>
           <td class="linux-virtualization">
@@ -2439,6 +2508,9 @@
           <td class="vpc-only">
             Yes
           </td>
+          <td class="ipv6-support">
+            Yes
+          </td>
           <td class="linux-virtualization">
             HVM
           </td>
@@ -2532,6 +2604,9 @@
             Yes
           </td>
           <td class="vpc-only">
+            Yes
+          </td>
+          <td class="ipv6-support">
             Yes
           </td>
           <td class="linux-virtualization">
@@ -2629,6 +2704,9 @@
           <td class="vpc-only">
             Yes
           </td>
+          <td class="ipv6-support">
+            Yes
+          </td>
           <td class="linux-virtualization">
             HVM
           </td>
@@ -2724,6 +2802,9 @@
           <td class="vpc-only">
             Yes
           </td>
+          <td class="ipv6-support">
+            Yes
+          </td>
           <td class="linux-virtualization">
             HVM
           </td>
@@ -2817,6 +2898,9 @@
             Yes
           </td>
           <td class="vpc-only">
+            Yes
+          </td>
+          <td class="ipv6-support">
             Yes
           </td>
           <td class="linux-virtualization">
@@ -2915,6 +2999,9 @@
           <td class="vpc-only">
             No
           </td>
+          <td class="ipv6-support">
+            No
+          </td>
           <td class="linux-virtualization">
             HVM, PV
           </td>
@@ -3009,6 +3096,9 @@
             No
           </td>
           <td class="vpc-only">
+            No
+          </td>
+          <td class="ipv6-support">
             No
           </td>
           <td class="linux-virtualization">
@@ -3109,6 +3199,9 @@
           <td class="vpc-only">
             No
           </td>
+          <td class="ipv6-support">
+            No
+          </td>
           <td class="linux-virtualization">
             HVM, PV
           </td>
@@ -3207,6 +3300,9 @@
           <td class="vpc-only">
             No
           </td>
+          <td class="ipv6-support">
+            No
+          </td>
           <td class="linux-virtualization">
             HVM, PV
           </td>
@@ -3300,6 +3396,9 @@
             Yes
           </td>
           <td class="vpc-only">
+            Yes
+          </td>
+          <td class="ipv6-support">
             Yes
           </td>
           <td class="linux-virtualization">
@@ -3397,6 +3496,9 @@
           <td class="vpc-only">
             Yes
           </td>
+          <td class="ipv6-support">
+            Yes
+          </td>
           <td class="linux-virtualization">
             HVM
           </td>
@@ -3490,6 +3592,9 @@
             Yes
           </td>
           <td class="vpc-only">
+            Yes
+          </td>
+          <td class="ipv6-support">
             Yes
           </td>
           <td class="linux-virtualization">
@@ -3587,6 +3692,9 @@
           <td class="vpc-only">
             Yes
           </td>
+          <td class="ipv6-support">
+            Yes
+          </td>
           <td class="linux-virtualization">
             HVM
           </td>
@@ -3680,6 +3788,9 @@
             Yes
           </td>
           <td class="vpc-only">
+            Yes
+          </td>
+          <td class="ipv6-support">
             Yes
           </td>
           <td class="linux-virtualization">
@@ -3777,6 +3888,9 @@
           </td>
           <td class="vpc-only">
             No
+          </td>
+          <td class="ipv6-support">
+            Yes
           </td>
           <td class="linux-virtualization">
             HVM, PV
@@ -3876,6 +3990,9 @@
           <td class="vpc-only">
             No
           </td>
+          <td class="ipv6-support">
+            Yes
+          </td>
           <td class="linux-virtualization">
             HVM, PV
           </td>
@@ -3973,6 +4090,9 @@
           </td>
           <td class="vpc-only">
             No
+          </td>
+          <td class="ipv6-support">
+            Yes
           </td>
           <td class="linux-virtualization">
             HVM, PV
@@ -4072,6 +4192,9 @@
           <td class="vpc-only">
             No
           </td>
+          <td class="ipv6-support">
+            Yes
+          </td>
           <td class="linux-virtualization">
             HVM, PV
           </td>
@@ -4168,6 +4291,9 @@
           <td class="vpc-only">
             No
           </td>
+          <td class="ipv6-support">
+            Yes
+          </td>
           <td class="linux-virtualization">
             HVM, PV
           </td>
@@ -4263,6 +4389,9 @@
           <td class="vpc-only">
             Yes
           </td>
+          <td class="ipv6-support">
+            Yes
+          </td>
           <td class="linux-virtualization">
             HVM
           </td>
@@ -4350,6 +4479,9 @@
           <td class="vpc-only">
             Yes
           </td>
+          <td class="ipv6-support">
+            Yes
+          </td>
           <td class="linux-virtualization">
             HVM
           </td>
@@ -4435,6 +4567,9 @@
             Yes
           </td>
           <td class="vpc-only">
+            Yes
+          </td>
+          <td class="ipv6-support">
             Yes
           </td>
           <td class="linux-virtualization">
@@ -4525,6 +4660,9 @@
             No
           </td>
           <td class="vpc-only">
+            No
+          </td>
+          <td class="ipv6-support">
             No
           </td>
           <td class="linux-virtualization">
@@ -4623,6 +4761,9 @@
           <td class="vpc-only">
             No
           </td>
+          <td class="ipv6-support">
+            No
+          </td>
           <td class="linux-virtualization">
             HVM
           </td>
@@ -4711,6 +4852,9 @@
             Yes
           </td>
           <td class="vpc-only">
+            Yes
+          </td>
+          <td class="ipv6-support">
             Yes
           </td>
           <td class="linux-virtualization">
@@ -4811,6 +4955,9 @@
           <td class="vpc-only">
             Yes
           </td>
+          <td class="ipv6-support">
+            Yes
+          </td>
           <td class="linux-virtualization">
             HVM
           </td>
@@ -4904,6 +5051,9 @@
             Yes
           </td>
           <td class="vpc-only">
+            Yes
+          </td>
+          <td class="ipv6-support">
             Yes
           </td>
           <td class="linux-virtualization">
@@ -5001,6 +5151,9 @@
           <td class="vpc-only">
             Yes
           </td>
+          <td class="ipv6-support">
+            Yes
+          </td>
           <td class="linux-virtualization">
             HVM
           </td>
@@ -5094,6 +5247,9 @@
             Yes
           </td>
           <td class="vpc-only">
+            Yes
+          </td>
+          <td class="ipv6-support">
             Yes
           </td>
           <td class="linux-virtualization">
@@ -5191,6 +5347,9 @@
           <td class="vpc-only">
             Yes
           </td>
+          <td class="ipv6-support">
+            Yes
+          </td>
           <td class="linux-virtualization">
             HVM
           </td>
@@ -5284,6 +5443,9 @@
             Yes
           </td>
           <td class="vpc-only">
+            Yes
+          </td>
+          <td class="ipv6-support">
             Yes
           </td>
           <td class="linux-virtualization">
@@ -5381,6 +5543,9 @@
           <td class="vpc-only">
             Yes
           </td>
+          <td class="ipv6-support">
+            Yes
+          </td>
           <td class="linux-virtualization">
             HVM
           </td>
@@ -5476,6 +5641,9 @@
           </td>
           <td class="vpc-only">
             No
+          </td>
+          <td class="ipv6-support">
+            Yes
           </td>
           <td class="linux-virtualization">
             HVM
@@ -5575,6 +5743,9 @@
           <td class="vpc-only">
             No
           </td>
+          <td class="ipv6-support">
+            Yes
+          </td>
           <td class="linux-virtualization">
             HVM
           </td>
@@ -5672,6 +5843,9 @@
           </td>
           <td class="vpc-only">
             No
+          </td>
+          <td class="ipv6-support">
+            Yes
           </td>
           <td class="linux-virtualization">
             HVM
@@ -5771,6 +5945,9 @@
           <td class="vpc-only">
             No
           </td>
+          <td class="ipv6-support">
+            Yes
+          </td>
           <td class="linux-virtualization">
             HVM
           </td>
@@ -5866,6 +6043,9 @@
           </td>
           <td class="vpc-only">
             No
+          </td>
+          <td class="ipv6-support">
+            Yes
           </td>
           <td class="linux-virtualization">
             HVM
@@ -5965,6 +6145,9 @@
           <td class="vpc-only">
             No
           </td>
+          <td class="ipv6-support">
+            Yes
+          </td>
           <td class="linux-virtualization">
             HVM
           </td>
@@ -6062,6 +6245,9 @@
           </td>
           <td class="vpc-only">
             No
+          </td>
+          <td class="ipv6-support">
+            Yes
           </td>
           <td class="linux-virtualization">
             HVM
@@ -6161,6 +6347,9 @@
           <td class="vpc-only">
             No
           </td>
+          <td class="ipv6-support">
+            Yes
+          </td>
           <td class="linux-virtualization">
             HVM
           </td>
@@ -6256,6 +6445,9 @@
           </td>
           <td class="vpc-only">
             No
+          </td>
+          <td class="ipv6-support">
+            Yes
           </td>
           <td class="linux-virtualization">
             HVM
@@ -6355,6 +6547,9 @@
           <td class="vpc-only">
             No
           </td>
+          <td class="ipv6-support">
+            Yes
+          </td>
           <td class="linux-virtualization">
             HVM
           </td>
@@ -6444,6 +6639,9 @@
           </td>
           <td class="vpc-only">
             No
+          </td>
+          <td class="ipv6-support">
+            Yes
           </td>
           <td class="linux-virtualization">
             HVM
@@ -6535,6 +6733,9 @@
           <td class="vpc-only">
             No
           </td>
+          <td class="ipv6-support">
+            Yes
+          </td>
           <td class="linux-virtualization">
             HVM
           </td>
@@ -6625,6 +6826,9 @@
           <td class="vpc-only">
             No
           </td>
+          <td class="ipv6-support">
+            Yes
+          </td>
           <td class="linux-virtualization">
             HVM
           </td>
@@ -6713,6 +6917,9 @@
           <td class="vpc-only">
             No
           </td>
+          <td class="ipv6-support">
+            No
+          </td>
           <td class="linux-virtualization">
             Unknown
           </td>
@@ -6793,6 +7000,9 @@
           <td class="vpc-only">
             No
           </td>
+          <td class="ipv6-support">
+            No
+          </td>
           <td class="linux-virtualization">
             Unknown
           </td>
@@ -6836,7 +7046,7 @@
       </p>
       <p>
         <strong>How?</strong>
-        Data is scraped from multiple pages on the AWS site. This was last done at 2017-01-31 11:17:36 UTC.
+        Data is scraped from multiple pages on the AWS site. This was last done at 2017-02-02 23:28:25 UTC.
       </p>
 
       <p class="bg-warning">

--- a/www/instances.json
+++ b/www/instances.json
@@ -392,6 +392,7 @@
       "ips_per_eni": 4,
       "max_enis": 2
     },
+    "ipv6_support": false,
     "base_performance": null,
     "arch": [
       "i386",
@@ -806,6 +807,7 @@
       "ips_per_eni": 6,
       "max_enis": 2
     },
+    "ipv6_support": false,
     "base_performance": null,
     "arch": [
       "i386",
@@ -1220,6 +1222,7 @@
       "ips_per_eni": 10,
       "max_enis": 3
     },
+    "ipv6_support": false,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -1633,6 +1636,7 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
+    "ipv6_support": false,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -1956,6 +1960,7 @@
       "ips_per_eni": 6,
       "max_enis": 2
     },
+    "ipv6_support": false,
     "base_performance": null,
     "arch": [
       "i386",
@@ -2370,6 +2375,7 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
+    "ipv6_support": false,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -2615,6 +2621,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": false,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -2678,6 +2685,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": false,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -3091,6 +3099,7 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
+    "ipv6_support": false,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -3504,6 +3513,7 @@
       "ips_per_eni": 30,
       "max_enis": 4
     },
+    "ipv6_support": false,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -3917,6 +3927,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": false,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -4120,6 +4131,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": false,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -4321,6 +4333,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": false,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -4651,6 +4664,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": false,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -4975,6 +4989,7 @@
       "ips_per_eni": 2,
       "max_enis": 2
     },
+    "ipv6_support": false,
     "base_performance": null,
     "arch": [
       "i386",
@@ -5427,6 +5442,7 @@
       "ips_per_eni": 2,
       "max_enis": 2
     },
+    "ipv6_support": true,
     "base_performance": 0.05,
     "arch": [
       "x86_64"
@@ -6073,6 +6089,7 @@
       "ips_per_eni": 2,
       "max_enis": 2
     },
+    "ipv6_support": true,
     "base_performance": 0.1,
     "arch": [
       "x86_64",
@@ -6720,6 +6737,7 @@
       "ips_per_eni": 4,
       "max_enis": 2
     },
+    "ipv6_support": true,
     "base_performance": 0.2,
     "arch": [
       "x86_64",
@@ -7367,6 +7385,7 @@
       "ips_per_eni": 6,
       "max_enis": 3
     },
+    "ipv6_support": true,
     "base_performance": 0.4,
     "arch": [
       "x86_64"
@@ -8013,6 +8032,7 @@
       "ips_per_eni": 12,
       "max_enis": 3
     },
+    "ipv6_support": true,
     "base_performance": 0.6,
     "arch": [
       "x86_64"
@@ -8659,6 +8679,7 @@
       "ips_per_eni": 15,
       "max_enis": 3
     },
+    "ipv6_support": true,
     "base_performance": 0.9,
     "arch": [
       "x86_64"
@@ -9305,6 +9326,7 @@
       "ips_per_eni": 15,
       "max_enis": 3
     },
+    "ipv6_support": true,
     "base_performance": 1.35,
     "arch": [
       "x86_64"
@@ -10146,6 +10168,7 @@
       "ips_per_eni": 10,
       "max_enis": 2
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -10987,6 +11010,7 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -11828,6 +11852,7 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -12669,6 +12694,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -13510,6 +13536,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -14351,6 +14378,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -14896,6 +14924,7 @@
       "ips_per_eni": 6,
       "max_enis": 2
     },
+    "ipv6_support": false,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -15472,6 +15501,7 @@
       "ips_per_eni": 10,
       "max_enis": 3
     },
+    "ipv6_support": false,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -16048,6 +16078,7 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
+    "ipv6_support": false,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -16624,6 +16655,7 @@
       "ips_per_eni": 30,
       "max_enis": 4
     },
+    "ipv6_support": false,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -17470,6 +17502,7 @@
       "ips_per_eni": 10,
       "max_enis": 3
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -18311,6 +18344,7 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -19152,6 +19186,7 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -19993,6 +20028,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -20834,6 +20870,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -21366,6 +21403,7 @@
       "ips_per_eni": 10,
       "max_enis": 3
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -21942,6 +21980,7 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -22518,6 +22557,7 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -23094,6 +23134,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -23670,6 +23711,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -23818,6 +23860,7 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -23961,6 +24004,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -24104,6 +24148,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -24541,6 +24586,7 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
+    "ipv6_support": false,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -24800,6 +24846,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": false,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -25537,6 +25584,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -26274,6 +26322,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -27119,6 +27168,7 @@
       "ips_per_eni": 10,
       "max_enis": 3
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -27960,6 +28010,7 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -28801,6 +28852,7 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -29642,6 +29694,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -30483,6 +30536,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -31324,6 +31378,7 @@
       "ips_per_eni": 50,
       "max_enis": 15
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -32057,6 +32112,7 @@
       "ips_per_eni": 10,
       "max_enis": 3
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -32794,6 +32850,7 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -33531,6 +33588,7 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -34268,6 +34326,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -35005,6 +35064,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -35688,6 +35748,7 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -36371,6 +36432,7 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -37054,6 +37116,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -37737,6 +37800,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -38164,6 +38228,7 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -38591,6 +38656,7 @@
       "ips_per_eni": 15,
       "max_enis": 4
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -39018,6 +39084,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -39445,6 +39512,7 @@
       "ips_per_eni": 30,
       "max_enis": 8
     },
+    "ipv6_support": true,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -39476,6 +39544,7 @@
     "pretty_name": "F1 Double Extra Large",
     "pricing": {},
     "vpc": null,
+    "ipv6_support": false,
     "base_performance": null,
     "arch": [
       "x86_64"
@@ -39505,6 +39574,7 @@
     "pretty_name": "F1 16xlarge",
     "pricing": {},
     "vpc": null,
+    "ipv6_support": false,
     "base_performance": null,
     "arch": [
       "x86_64"

--- a/www/rds/index.html
+++ b/www/rds/index.html
@@ -21,7 +21,7 @@
     <h1>RDSInstances.info <small>Easy Amazon RDS Instance Comparison</small></h1>
     
 
-      <p class="pull-right label label-info">Last Update: 2017-01-23 21:43:49 UTC</p>
+      <p class="pull-right label label-info">Last Update: 2017-02-02 23:28:26 UTC</p>
       <ul class="nav nav-tabs">
         <li role="presentation" class=""><a href="/">EC2</a></li>
         <li role="presentation" class="active"><a href="/rds/">RDS</a></li>
@@ -2356,7 +2356,7 @@
       </p>
       <p>
         <strong>How?</strong>
-        Data is scraped from multiple pages on the AWS site. This was last done at 2017-01-23 21:43:49 UTC.
+        Data is scraped from multiple pages on the AWS site. This was last done at 2017-02-02 23:28:26 UTC.
       </p>
 
       <p class="bg-warning">


### PR DESCRIPTION
It turns out not all instance families support IPv6. This page has the details: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#instance-networking-storage

Curiously, that page says P2 instances support it, but the ec2 launch wizard has a "-" and not "Yes" in the IPv6 column. Not sure what's going on here.

I removed the `scrape_families` function since it was only used in one place and by doing so I didn't have to make a second HTTP request to get that table. Also, it appears this new column is a default column, but I'm not sure why. Might want to change that.

Thanks for the website by the way! It has been very helpful in comparing instances.