### PR TITLE
Feature Request: CSV Export #166

### DIFF
--- a/in/base.mako
+++ b/in/base.mako
@@ -52,7 +52,11 @@
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript" charset="utf-8"></script>
     <script src="/bootstrap/js/bootstrap.min.js" type="text/javascript" charset="utf-8"></script>
-    <script type="text/javascript" charset="utf8" src="https://ajax.aspnetcdn.com/ajax/jquery.dataTables/1.10.4/jquery.dataTables.min.js"></script>
+    <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.10.13/js/jquery.dataTables.min.js"></script>
+    <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/buttons/1.2.4/js/dataTables.buttons.min.js"></script>
+    <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/buttons/1.2.4/js/buttons.flash.min.js"></script>
+    <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/buttons/1.2.4/js/buttons.html5.min.js"></script>
+    <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/buttons/1.2.4/js/buttons.print.min.js"></script>
     <script src="/store/store.js" type="text/javascript" charset="utf-8"></script>
     <script src="/default.js" type="text/javascript" charset="utf-8"></script>
 

--- a/www/default.js
+++ b/www/default.js
@@ -79,8 +79,17 @@ function init_data_table() {
       redraw_costs();
     },
     // Store filtering, sorting, etc - core datatable feature
-    'stateSave': true
+    'stateSave': true,
+    // Allow export to CSV
+    'buttons': ['csv']
   });
+
+  g_data_table
+    .buttons()
+    .container()
+    .find('a')
+    .addClass('btn btn-primary')
+    .appendTo($('#menu > div'));
 
   return g_data_table;
 }


### PR DESCRIPTION
This integrates DataTables buttons into the project in order to enable export
as CSV functionality.

See here: https://datatables.net/extensions/buttons/examples/initialisation/export.html

(There are a couple other features, but in the interest of space, kept just the CSV)

Change to UI

<img width="1272" alt="screen shot 2017-02-17 at 12 44 41 am" src="https://cloud.githubusercontent.com/assets/936002/23058585/817a9ae6-f4aa-11e6-8068-6237fdb9599c.png">
