### PR TITLE
Large refactoring of storage scraping, fixes #220

### DIFF
--- a/in/index.html.mako
+++ b/in/index.html.mako
@@ -113,6 +113,7 @@
           <th class="ebs-max-bandwidth">EBS Optimized: Max Bandwidth</th>
           <th class="ebs-throughput">EBS Optimized: Throughput</th>
           <th class="ebs-iops">EBS Optimized: Max 16K IOPS</th>
+          <th class="trim-support">TRIM Support</th>
           <th class="maxips">
             <abbr title="Adding additional IPs requires launching the instance in a VPC.">Max IPs</abbr>
           </th>
@@ -230,6 +231,9 @@
             <span sort="${inst['ebs_iops']}">
               ${inst['ebs_iops']} IOPS
             </span>
+          </td>
+          <td class="trim-support">
+            ${'Yes' if inst['trim_support'] else 'No'}
           </td>
           <td class="maxips">
             % if inst['vpc']:

--- a/scrape.py
+++ b/scrape.py
@@ -26,6 +26,7 @@ class Instance(object):
         # self.hvm_only = False
         self.vpc_only = False
         self.ipv6_support = False
+        self.trim_support = False
         self.placement_group_support = False
         self.pretty_name = ''
 
@@ -51,6 +52,7 @@ class Instance(object):
                  linux_virtualization_types=self.linux_virtualization_types,
                  generation=self.generation,
                  vpc_only=self.vpc_only,
+                 trim_support=self.trim_support,
                  ipv6_support=self.ipv6_support)
         if self.ebs_only:
             d['storage'] = None
@@ -475,6 +477,16 @@ def add_vpconly_detail(instances):
                 i.vpc_only = True
 
 
+def add_trim_support_detail(instances):
+    # specific instances support the TRIM command for instance store SSDs
+    # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ssd-instance-store.html#InstanceStoreTrimSupport
+    trim_supported_families = ('i2', 'i3', 'r3')
+    for i in instances:
+        for family in trim_supported_families:
+            if i.instance_type.startswith(family):
+                i.trim_support = True
+
+
 def add_t2_credits(instances):
     tree = etree.parse(urllib2.urlopen("http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-instances.html"),
                        etree.HTMLParser())
@@ -550,6 +562,7 @@ def scrape(data_file):
     add_linux_ami_info(all_instances)
     print "Adding additional details..."
     add_vpconly_detail(all_instances)
+    add_trim_support_detail(all_instances)
     add_t2_credits(all_instances)
     add_pretty_names(all_instances)
 

--- a/www/default.js
+++ b/www/default.js
@@ -60,6 +60,7 @@ function init_data_table() {
           "ebs-max-bandwidth",
           "cost-ebs-optimized",
           "trim-support",
+          "warmed-up",
           "ipv6-support",
           "placement-group-support",
           "vpc-only"

--- a/www/default.js
+++ b/www/default.js
@@ -59,6 +59,7 @@ function init_data_table() {
           "ebs-iops",
           "ebs-max-bandwidth",
           "cost-ebs-optimized",
+          "trim-support",
           "ipv6-support",
           "placement-group-support",
           "vpc-only"


### PR DESCRIPTION
Notable changes
- Parse storage info from http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html
  instead of the instance information page.
- Add a table column about need of warming up storage volumes
- Add a table column about SSD TRIM support
- Add information about additional swap volumes
- Add information about NVMe for the SSD volumes
- Use integers as storage measurement unit
    
Known regressions due to issues in the data source, already reported to AWS:
- incorrect information for i3.8xlarge and i3.16xlarge - update: fixed already
- missing data for F1 instance types, incorrectly displayed as EBS-only