### PR TITLE
Temporary fix for the sorting bug when region changed

### DIFF
--- a/www/default.js
+++ b/www/default.js
@@ -143,9 +143,11 @@ function change_cost(duration) {
     per_time = elem.data("pricing")[g_settings.region];
     if (per_time && !isNaN(per_time)) {
       per_time = (per_time * multiplier).toFixed(3);
-      elem.text("$" + per_time + " " + duration);
+      elem.empty();
+      elem.append('<span sort="' + per_time + '">$' + per_time + ' ' + duration + '</span>');
     } else {
-      elem.text("unavailable");
+        elem.empty();
+        elem.append('<span sort="0">unavailable</span>');
     }
   });
 
@@ -154,7 +156,8 @@ function change_cost(duration) {
     per_time = elem.data("pricing")[g_settings.region];
 
     if (!per_time) {
-      elem.text("unavailable");
+      elem.empty();
+      elem.append('<span sort="0">unavailable</span>');
       return;
     }
 
@@ -162,9 +165,11 @@ function change_cost(duration) {
 
     if (per_time && !isNaN(per_time)) {
       per_time = (per_time * multiplier).toFixed(3);
-      elem.text("$" + per_time + " " + duration);
+      elem.empty();
+      elem.append('<span sort="' + per_time + '">$' + per_time + ' ' + duration + '</span>');
     } else {
-      elem.text("unavailable");
+      elem.empty();
+      elem.append('<span sort="0">unavailable</span>');
     }
   });
 
@@ -173,9 +178,11 @@ function change_cost(duration) {
     per_time = elem.data("pricing")[g_settings.region];
     if (per_time && !isNaN(per_time)) {
       per_time = (per_time * multiplier).toFixed(3);
-      elem.text("$" + per_time + " " + duration);
+      elem.empty();
+      elem.append('<span sort="' + per_time + '">$' + per_time + ' ' + duration + '</span>');
     } else {
-      elem.text("unavailable");
+      elem.empty();
+      elem.append('<span sort="0">unavailable</span>');
     }
   });
 
@@ -197,6 +204,7 @@ function change_region(region) {
   });
   $("#region-dropdown .dropdown-toggle .text").text(region_name);
   change_cost(g_settings.cost_duration);
+  g_data_table.rows().invalidate().draw();
 }
 
 function change_reserved_term(term) {


### PR DESCRIPTION
1. Alongside the display value, the sort attribute of span is also changed now
2. After region change, the datatable is notified of data change through the use of datatable.rows().invalidate().draw()