### PR TITLE
issue in add_linux_ami_info

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -468,7 +468,7 @@ def add_linux_ami_info(instances):
     checkmark_char = u'\u2713'
     url = "http://aws.amazon.com/amazon-linux-ami/instance-type-matrix/"
     tree = etree.parse(urllib2.urlopen(url), etree.HTMLParser())
-    table = tree.xpath('//div[@class="aws-table "]/table')[0]
+    table = tree.xpath('//div[@class="aws-table"]/table')[0]
     rows = table.xpath('.//tr[./td]')[1:]  # ignore header
 
     for r in rows:


### PR DESCRIPTION
seems that there was an unneeded space in the class name for the instance type matrix table.