### PR TITLE
Convert GPU count to an int to ensure type consistency

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -180,7 +180,7 @@ def parse_gpus(tr, by_type):
     instance = by_type.get(instance_type, None)
     if instance is None:
         return
-    instance.GPU = totext(cols[1])
+    instance.GPU = locale.atoi(totext(cols[1]))
 
 
 def parse_instance_fpgas(tr, by_type):


### PR DESCRIPTION
I need the GPU field to be consistently typed in order to support the implementation of https://github.com/cristim/autospotting/issues/126

My Go library providing instance type information based on the ec2instances.info data (https://github.com/cristim/ec2-instances-info) would otherwise fail to parse the JSON data structure since the type defaults to int for the zero value but it's currently a string for all non-zero values.