### PR TITLE
Packaging instance data as a pypi library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 *.pyc
 *.DS_store
 .idea
+*.egg-info
 env
 venv
 .fab_tasks~
 .env
+build
+dist
+ec2instances

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md LICENSE
+include ec2instances
+exclude requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 package:
 	python scripts/package.py
 	pip install -e .
+	python setup.py sdist bdist_wheel
 
 pypi: package
-	python setup.py sdist bdist_wheel
+	python setup.py sdist bdist_wheel upload
 
 publish: package pypi

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+package:
+	python scripts/package.py
+	pip install -e .
+
+pypi: package
+	python setup.py sdist bdist_wheel
+
+publish: package pypi

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 package:
 	python scripts/package.py
 	pip install -e .
-	python setup.py sdist bdist_wheel
 
 pypi: package
 	python setup.py sdist bdist_wheel upload

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import pprint
+import json
+import subprocess
+
+root_dir = subprocess.check_output([
+    'git', 'rev-parse', '--show-toplevel'
+    ]).decode().strip()
+
+
+def path(s):
+    return "{}/{}".format(root_dir, s)
+
+
+# Create the output directory
+subprocess.call(['mkdir', '-p', '{}/ec2instances/info'.format(root_dir)])
+# Make the project a module
+subprocess.call(['touch', '{}/ec2instances/__init__.py'.format(root_dir)])
+subprocess.call(['touch', '{}/ec2instances/info/__init__.py'.format(root_dir)])
+
+
+with open(path('ec2instances/info/__init__.py'), 'a') as output:
+    # Final output will look like the following, though pretty-printed:
+    #
+    #  ec2 = [{'instance_type': 't2.micro', ...}, ...]
+    #  rds = [{'instance_type': 'db.t2.small', ...}, ...]
+    #
+    with open(path('www/instances.json'), 'r') as input:
+        rds = json.loads(input.read())
+        output.write("ec2 = {}".format(pprint.pformat(rds)))
+
+    output.write("\n")
+
+    with open(path('www/rds/instances.json'), 'r') as input:
+        rds = json.loads(input.read())
+        output.write("rds = {}".format(pprint.pformat(rds)))

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -17,10 +17,9 @@ def path(s):
 subprocess.call(['mkdir', '-p', '{}/ec2instances/info'.format(root_dir)])
 # Make the project a module
 subprocess.call(['touch', '{}/ec2instances/__init__.py'.format(root_dir)])
-subprocess.call(['touch', '{}/ec2instances/info/__init__.py'.format(root_dir)])
 
 
-with open(path('ec2instances/info/__init__.py'), 'a') as output:
+with open(path('ec2instances/info/__init__.py'), 'w') as output:
     # Final output will look like the following, though pretty-printed:
     #
     #  ec2 = [{'instance_type': 't2.micro', ...}, ...]
@@ -35,3 +34,5 @@ with open(path('ec2instances/info/__init__.py'), 'a') as output:
     with open(path('www/rds/instances.json'), 'r') as input:
         rds = json.loads(input.read())
         output.write("rds = {}".format(pprint.pformat(rds)))
+
+    output.write("\n")

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -26,8 +26,8 @@ with open(path('ec2instances/info/__init__.py'), 'w') as output:
     #  rds = [{'instance_type': 'db.t2.small', ...}, ...]
     #
     with open(path('www/instances.json'), 'r') as input:
-        rds = json.loads(input.read())
-        output.write("ec2 = {}".format(pprint.pformat(rds)))
+        ec2 = json.loads(input.read())
+        output.write("ec2 = {}".format(pprint.pformat(ec2)))
 
     output.write("\n")
 

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -14,9 +14,9 @@ def path(s):
 
 
 # Create the output directory
-subprocess.call(['mkdir', '-p', '{}/ec2instances/info'.format(root_dir)])
+subprocess.call(['mkdir', '-p', path('ec2instances/info')])
 # Make the project a module
-subprocess.call(['touch', '{}/ec2instances/__init__.py'.format(root_dir)])
+subprocess.call(['touch', path('ec2instances/__init__.py')])
 
 
 with open(path('ec2instances/info/__init__.py'), 'w') as output:

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,5 @@ setup(
     author='Garret Heaton',
     author_email='github@garretheaton.com',
     url='https://github.com/powdahound/ec2instances.info',
-    install_requires=[],
-    extras_require=None,
-    include_package_data=True,
     license="MIT",
 )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 setup(
     name='ec2instances.info',
     packages=['ec2instances.info'],
-    version='0.0.1',
+    version='0.0.2',
     description='The community-maintained dataset of ec2 instance types'
                 ' and pricing',
     author='Garret Heaton',

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+from __future__ import unicode_literals
+from setuptools import setup
+
+
+setup(
+    name='ec2instances.info',
+    packages=['ec2instances.info'],
+    version='0.0.1',
+    description='The community-maintained dataset of ec2 instance types'
+                ' and pricing',
+    author='Garret Heaton',
+    author_email='github@garretheaton.com',
+    url='https://github.com/powdahound/ec2instances.info',
+    install_requires=[],
+    extras_require=None,
+    include_package_data=True,
+    license="MIT",
+)


### PR DESCRIPTION
This adds a build process that turns the final json output into Python source data that client libraries can include. It publishes a very slim artifact to PyPi as 'ec2instances.info'

There are various gists and snippets of code on StackOverflow for screen-scraping ec2instances.info. This allows at least Python developers to avoid having to do that.

Published as ec2instances.info-0.0.1 on PyPi and I've added @powdahound as an owner