### PR TITLE
Add drop-down item for AWS GovCloud

### DIFF
--- a/in/index.html.mako
+++ b/in/index.html.mako
@@ -31,6 +31,7 @@
             <li><a href="javascript:;" data-region='us-east-2'>US East (Ohio)</a></li>
             <li><a href="javascript:;" data-region='us-west-1'>US West (Northern California)</a></li>
             <li><a href="javascript:;" data-region='us-west-2'>US West (Oregon)</a></li>
+            <li><a href="javascript:;" data-region='us-gov-west-1'>AWS GovCloud (US)</a></li>
           </ul>
         </div>
 

--- a/in/rds.html.mako
+++ b/in/rds.html.mako
@@ -33,7 +33,7 @@
             <li><a href="javascript:;" data-region='us-east-2'>US East (Ohio)</a></li>
             <li><a href="javascript:;" data-region='us-west-1'>US West (Northern California)</a></li>
             <li><a href="javascript:;" data-region='us-west-2'>US West (Oregon)</a></li>
-
+            <li><a href="javascript:;" data-region='us-gov-west-1'>AWS GovCloud (US)</a></li>
           </ul>
         </div>
 


### PR DESCRIPTION
The data is already being populated as far as I can tell. We just need a drop-down entry to fix it.
You have to manually edit the URL currently.

See: https://www.ec2instances.info/?region=us-gov-west-1&cost_duration=monthly&selected=m4.2xlarge

Fixes: https://github.com/powdahound/ec2instances.info/issues/194