### PR TITLE
two fixes on the rds scrapper

### DIFF
--- a/rds.py
+++ b/rds.py
@@ -70,6 +70,7 @@ def scrape(output_file, input_file=None):
         "Asia Pacific (Singapore)": 'ap-southeast-1',
         "Asia Pacific (Sydney)": 'ap-southeast-2',
         "Asia Pacific (Tokyo)": 'ap-northeast-1',
+        "Asia Pacific (Osaka-Local)": 'ap-northeast-3',
         "Canada (Central)": 'ca-central-1',
         "EU (Frankfurt)": 'eu-central-1',
         "EU (Ireland)": 'eu-west-1',
@@ -85,7 +86,7 @@ def scrape(output_file, input_file=None):
     # loop through products, and only fetch available instances for now
     for sku, product in data['products'].iteritems():
 
-        if product['productFamily'] == 'Database Instance':
+        if product.get('productFamily', None) == 'Database Instance':
             # map the region
             try:
                 region = regions[product['attributes']['location']]


### PR DESCRIPTION
* add the region 'Asia Pacific (Osaka-Local)' aka ap-northeast-3
* be more robust in the scrapping if 'productFamily' is not there.
  With the new region we get the following products without
'productFamily field':
``` python
{u'attributes': {u'fromLocation': u'Asia Pacific (Osaka-Local)',
                 u'fromLocationType': u'AWS Region',
                 u'operation': u'',
                 u'servicecode': u'AWSDataTransfer',
                 u'servicename': u'AWS Data Transfer',
                 u'toLocation': u'External',
                 u'toLocationType': u'Other',
                 u'transferType': u'Inter Region Peering Data Transfer Outbound',
                 u'usagetype': u'APN3-AWS-Out-Bytes'},
 u'sku': u'8FHV4XVBMZ49CCC4'}
{u'attributes': {u'fromLocation': u'External',
                 u'fromLocationType': u'AWS Region',
                 u'operation': u'',
                 u'servicecode': u'AWSDataTransfer',
                 u'servicename': u'AWS Data Transfer',
                 u'toLocation': u'Asia Pacific (Osaka-Local)',
                 u'toLocationType': u'AWS Region',
                 u'transferType': u'Inter Region Peering Data Transfer Inbound',
                 u'usagetype': u'APN3-AWS-In-Bytes'},
 u'sku': u'FM279BJD58XPQ8RS'}
```