### PR TITLE
fix out of range issue when parsing for ec2 info

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -263,7 +263,7 @@ def scrape_instances():
     all_gen = prev_gen + current_gen
 
     hdrs = features_details.xpath('tr')[0]
-    if totext(hdrs[0]).lower() == '' and 'ipv6 support' in totext(hdrs[7]).lower():
+    if len(hdrs) > 8 and totext(hdrs[0]).lower() == '' and 'ipv6 support' in totext(hdrs[7]).lower():
         feature_support(features_details, all_gen)
 
     return all_gen

--- a/scrape.py
+++ b/scrape.py
@@ -263,7 +263,7 @@ def scrape_instances():
     all_gen = prev_gen + current_gen
 
     hdrs = features_details.xpath('tr')[0]
-    if len(hdrs) > 8 and totext(hdrs[0]).lower() == '' and 'ipv6 support' in totext(hdrs[7]).lower():
+    if len(hdrs) > 7 and totext(hdrs[0]).lower() == '' and 'ipv6 support' in totext(hdrs[7]).lower():
         feature_support(features_details, all_gen)
 
     return all_gen


### PR DESCRIPTION
Hello,

Right now the scrapper is crashing with:

```
Traceback (most recent call last):
  File "scrape.py", line 726, in <module>
    scrape('www/instances.json')
  File "scrape.py", line 697, in scrape
    all_instances = scrape_instances()
  File "scrape.py", line 266, in scrape_instances
    if totext(hdrs[0]).lower() == '' and 'ipv6 support' in totext(hdrs[7]).lower():
  File "src/lxml/etree.pyx", line 1180, in lxml.etree._Element.__getitem__ (src/lxml/etree.c:56524)
IndexError: list index out of range
```

I've added a simple check on the length of the hdrs list, now it technically works, but I'm not sure if it's correct or not from a "functional" perspective.