### PR TITLE
Pin Fabric to a version prior to 2.0.0 release (fixes builds)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fabric
+fabric<2.0.0
 boto
 mako
 lxml


### PR DESCRIPTION
The update to the Fabric package causes the tool to fail complaining about `fabric.api` not existing any longer, pinning to the 1.x versions fixes this.

I'm not confident enough to try updating it to the 2.x release so hopefully this is acceptable as it should get the builds passing again :)