### PR TITLE
Fixing Issue 378 (UTF-8) char in ASCII output stream

### DIFF
--- a/render.py
+++ b/render.py
@@ -58,7 +58,7 @@ def render(data_file, template_file, destination_file):
     generated_at = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S UTC')
     with open(destination_file, 'w') as fh:
         try:
-            fh.write(template.render(instances=instances, generated_at=generated_at))
+            fh.write(template.render(instances=instances, generated_at=generated_at).encode('UTF-8'))
         except:
             print mako.exceptions.text_error_template().render()
 


### PR DESCRIPTION
Output was rendered as ASCII, so index.html page did't got rendered. see https://github.com/powdahound/ec2instances.info/issues/378
The error was:
```
Rendering to www/index.html...

Traceback (most recent call last):
  File "/Users/joergbaldzer/git/github/ec2instances.info/render.py", line 61, in render
    fh.write(template.render(instances=instances, generated_at=generated_at))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xae' in position 6289454: ordinal not in range(128)
```

So I add `.encode('UTF-8')` to the output of the render call.
Might be a quick fix because I don't know the code and other solutions might therefore be better.

