### PR TITLE
Switch from Fabric to Invoke

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 *.egg-info
 env
 venv
-.fab_tasks~
 .env
 build
 dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ python: 2.7
 install:
   - pip install -r requirements.txt
 script:
-  fab build deploy
+  invoke build deploy

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,10 @@ RUN pip install -r requirements.txt
 
 COPY . .
 
-ENV FAB_HOST=0.0.0.0 FAB_PORT=8080
+ENV HTTP_HOST=0.0.0.0 HTTP_PORT=8080
 
-RUN fab build
+RUN invoke build
 
 EXPOSE 8080
 
-CMD ["fab", "serve"]
+CMD ["invoke", "serve"]

--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@ Make sure you have LibXML and Python development files.  On Ubuntu, run `sudo ap
 3. `virtualenv env` (make sure you have virtualenv package installed)
 4. `source env/bin/activate`
 5. `pip install -r requirements.txt`
-6. `fab build`
-7. `fab serve`
+6. `invoke build`
+7. `invoke serve`
 8. Browse to http://localhost:8080
 9. `deactivate` (to exit virtualenv)
 
 
 ### Requirements
 
-- Python 2.7+ with virtualenv (not Python 3 yet due to Fabric dependency)
-- [Fabric](http://docs.fabfile.org/en/1.8/) 1.1+
+- Python 2.7+ with virtualenv (not Python 3 yet)
+- [Invoke](http://www.pyinvoke.org/)
 - [Boto](http://boto.readthedocs.org/en/latest/)
 - [Mako](http://www.makotemplates.org/)
 - [lxml](http://lxml.de/)
@@ -43,7 +43,7 @@ To build a docker image follow these steps:
 2. `cd ec2instances.info`
 3. `docker build -t ec2instances.info .`
 4. Start a container `docker run -d --name some-container -p 8080:8080 ec2instances.info`
-5. Update files `docker exec -it some-container bash -c "fab build"`
+5. Update files `docker exec -it some-container bash -c "invoke build"`
 
 Also this image can be found at quay.io/ssro/ec2instances.info
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-fabric<2.0.0
+invoke
+invocations
 boto
 mako
 lxml
-paramiko
-pycrypto
 requests==2.9.1


### PR DESCRIPTION
https://www.fabfile.org/upgrading.html#sidegrading-to-invoke

This reduces the number of dependencies needed for the project and also removes
the first stumbling block for running the project with Python 3.

Invoke makes use of a `Context` object which contains the context where the
tasks are run inside of. It is supplied to the tasks as the first positional
argument so I had to add a `c` argument to all the tasks to make this work.

Invoke doesn't have an `abort` function like Fabric has, so I have instead
simplified it to just print the abort message and then exit with a status code
of 1.