### PR TITLE
Python 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 *.egg-info
 env
 venv
-.fab_tasks~
 .env
 build
 dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ python: 2.7
 install:
   - pip install -r requirements.txt
 script:
-  fab build deploy
+  invoke build deploy

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,19 +2,20 @@ FROM centos:7
 
 MAINTAINER Sebastian Sasu <sebi@nologin.ro>
 
-ENV PACKAGES python-devel libxml2-devel libxslt-devel openssl-devel python2-pip gcc
+ENV PACKAGES python36-devel libxml2-devel libxslt-devel openssl-devel gcc
 
 RUN yum -y install epel-release && \
     yum -y update && \
     yum -y install ${PACKAGES} && \
     yum -y clean all && \
-    rm -rf /var/tmp/* /var/cache/yum/* /root/.cache
+    rm -rf /var/tmp/* /var/cache/yum/* /root/.cache && \
+    python3.6 -m ensurepip
 
 WORKDIR /opt/app
 
 COPY requirements.txt .
 
-RUN pip install -r requirements.txt
+RUN pip3.6 install -r requirements.txt
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,10 @@ RUN pip install -r requirements.txt
 
 COPY . .
 
-ENV FAB_HOST=0.0.0.0 FAB_PORT=8080
+ENV HTTP_HOST=0.0.0.0 HTTP_PORT=8080
 
-RUN fab build
+RUN invoke build
 
 EXPOSE 8080
 
-CMD ["fab", "serve"]
+CMD ["invoke", "serve"]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Make sure you have LibXML and Python development files.  On Ubuntu, run `sudo ap
 
 ### Requirements
 
-- Python 2.7+ with virtualenv (not Python 3 yet)
+- Python with virtualenv
 - [Invoke](http://www.pyinvoke.org/)
 - [Boto](http://boto.readthedocs.org/en/latest/)
 - [Mako](http://www.makotemplates.org/)

--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@ Make sure you have LibXML and Python development files.  On Ubuntu, run `sudo ap
 3. `virtualenv env` (make sure you have virtualenv package installed)
 4. `source env/bin/activate`
 5. `pip install -r requirements.txt`
-6. `fab build`
-7. `fab serve`
+6. `invoke build`
+7. `invoke serve`
 8. Browse to http://localhost:8080
 9. `deactivate` (to exit virtualenv)
 
 
 ### Requirements
 
-- Python 2.7+ with virtualenv (not Python 3 yet due to Fabric dependency)
-- [Fabric](http://docs.fabfile.org/en/1.8/) 1.1+
+- Python 2.7+ with virtualenv (not Python 3 yet)
+- [Invoke](http://www.pyinvoke.org/)
 - [Boto](http://boto.readthedocs.org/en/latest/)
 - [Mako](http://www.makotemplates.org/)
 - [lxml](http://lxml.de/)
@@ -43,7 +43,7 @@ To build a docker image follow these steps:
 2. `cd ec2instances.info`
 3. `docker build -t ec2instances.info .`
 4. Start a container `docker run -d --name some-container -p 8080:8080 ec2instances.info`
-5. Update files `docker exec -it some-container bash -c "fab build"`
+5. Update files `docker exec -it some-container bash -c "invoke build"`
 
 Also this image can be found at quay.io/ssro/ec2instances.info
 

--- a/in/index.html.mako
+++ b/in/index.html.mako
@@ -1,6 +1,7 @@
 <%!
   active_ = "ec2"
   import json
+  import six
 %>
 <%inherit file="base.mako" />
 
@@ -353,7 +354,7 @@
           ## note that the contents in these cost cells are overwritten by the JS change_cost() func, but the initial
           ## data here is used for sorting (and anyone with JS disabled...)
           ## for more info, see https://github.com/powdahound/ec2instances.info/issues/140
-          <td class="cost-ondemand cost-ondemand-${platform}" data-pricing='${json.dumps({r:p.get(platform, p.get('os',{})).get('ondemand') for r,p in inst['pricing'].iteritems()}) | h}'>
+          <td class="cost-ondemand cost-ondemand-${platform}" data-pricing='${json.dumps({r:p.get(platform, p.get('os',{})).get('ondemand') for r,p in six.iteritems(inst['pricing'])}) | h}'>
             % if inst['pricing'].get('us-east-1', {}).get(platform, {}).get('ondemand', 'N/A') != "N/A":
               <span sort="${inst['pricing']['us-east-1'][platform]['ondemand']}">
                 $${inst['pricing']['us-east-1'][platform]['ondemand']} hourly
@@ -362,7 +363,7 @@
               <span sort="999999">unavailable</span>
             % endif
           </td>
-          <td class="cost-reserved cost-reserved-${platform}" data-pricing='${json.dumps({r:p.get(platform, p.get('os',{})).get('reserved', {}) for r,p in inst['pricing'].iteritems()}) | h}'>
+          <td class="cost-reserved cost-reserved-${platform}" data-pricing='${json.dumps({r:p.get(platform, p.get('os',{})).get('reserved', {}) for r,p in six.iteritems(inst['pricing'])}) | h}'>
             % if inst['pricing'].get('us-east-1', {}).get(platform, {}).get('reserved', 'N/A') != "N/A":
               <span sort="${inst['pricing']['us-east-1'][platform]['reserved']['yrTerm1Standard.noUpfront']}">
                 $${inst['pricing']['us-east-1'][platform]['reserved']['yrTerm1Standard.noUpfront']} hourly
@@ -372,7 +373,7 @@
             % endif
           </td>
           % endfor
-          <td class="cost-ebs-optimized" data-pricing='${json.dumps({r:p.get('ebs', {}) for r,p in inst['pricing'].iteritems()}) | h}'>
+          <td class="cost-ebs-optimized" data-pricing='${json.dumps({r:p.get('ebs', {}) for r,p in six.iteritems(inst['pricing'])}) | h}'>
            % if inst['ebs_max_bandwidth']:
               % if inst['pricing'].get('us-east-1', {}).get('ebs', 'N/A') != "N/A":
                 <span sort="${inst['pricing']['us-east-1']['ebs']}">
@@ -385,7 +386,7 @@
               <span sort="999999">unavailable</span>
             % endif
           </td>
-          <td class="cost-emr cost-ondemand" data-pricing='${json.dumps({r:p.get('emr', {}).get('emr', {}) for r,p in inst['pricing'].iteritems()}) | h}'>
+          <td class="cost-emr cost-ondemand" data-pricing='${json.dumps({r:p.get('emr', {}).get('emr', {}) for r,p in six.iteritems(inst['pricing'])}) | h}'>
             % if inst['pricing'].get('us-east-1', {}).get("emr", {}):
               <span sort="${inst['pricing']['us-east-1']["emr"]['emr']}">
                 $${inst['pricing']['us-east-1']["emr"]['emr']} hourly

--- a/in/rds.html.mako
+++ b/in/rds.html.mako
@@ -1,6 +1,7 @@
 <%!
   active_ = "rds"
   import json
+  import six
 %>
 <%inherit file="base.mako" />
 
@@ -156,7 +157,7 @@
             % endif
           </td>
           % for platform in ['Aurora PostgreSQL', 'Aurora MySQL', 'MariaDB', 'MySQL', 'Oracle','PostgreSQL', 'SQL Server']:
-          <td class="cost-ondemand cost-ondemand-${platform}" data-pricing='${json.dumps({r:p.get(platform, p.get('os',{})).get('ondemand') for r,p in inst['pricing'].iteritems()}) | h}'>
+          <td class="cost-ondemand cost-ondemand-${platform}" data-pricing='${json.dumps({r:p.get(platform, p.get('os',{})).get('ondemand') for r,p in six.iteritems(inst['pricing'])}) | h}'>
             % if inst['pricing'].get('us-east-1', {}).get(platform, {}).get('ondemand', 'N/A') != "N/A":
               <span sort="${inst['pricing']['us-east-1'][platform]['ondemand']}">
                 $${inst['pricing']['us-east-1'][platform]['ondemand']} per hour
@@ -165,7 +166,7 @@
               <span sort="0">unavailable</span>
             % endif
           </td>
-          <td class="cost-reserved cost-reserved-${platform}" data-pricing='${json.dumps({r:p.get(platform, p.get('os',{})).get('reserved', {}) for r,p in inst['pricing'].iteritems()}) | h}'>
+          <td class="cost-reserved cost-reserved-${platform}" data-pricing='${json.dumps({r:p.get(platform, p.get('os',{})).get('reserved', {}) for r,p in six.iteritems(inst['pricing'])}) | h}'>
             % if inst['pricing'].get('us-east-1', {}).get(platform, {}).get('reserved', 'N/A') != "N/A":
               <span sort="${inst['pricing']['us-east-1'][platform]['reserved'].get('yrTerm1.noUpfront')}">
                 $${inst['pricing']['us-east-1'][platform]['reserved'].get('yrTerm1.noUpfront')} per hour

--- a/rds.py
+++ b/rds.py
@@ -207,7 +207,7 @@ def scrape(output_file, input_file=None):
     # write output to file
     encoder.FLOAT_REPR = lambda o: format(o, '.5f')
     with open(output_file, 'w') as outfile:
-        json.dump(instances.values(), outfile, indent=4)
+        json.dump(list(instances.values()), outfile, indent=4)
 
 
 if __name__ == '__main__':

--- a/rds.py
+++ b/rds.py
@@ -4,6 +4,8 @@ import json
 from json import encoder
 import sys
 
+import six
+
 
 def add_pretty_names(instances):
     family_names = {
@@ -87,7 +89,7 @@ def scrape(output_file, input_file=None):
     }
 
     # loop through products, and only fetch available instances for now
-    for sku, product in data['products'].iteritems():
+    for sku, product in six.iteritems(data['products']):
 
         if product.get('productFamily', None) == 'Database Instance':
             # map the region
@@ -117,9 +119,9 @@ def scrape(output_file, input_file=None):
                 instances[attributes['instance_type']]['pricing'] = {}
 
     # Parse ondemand pricing
-    for sku, offers in data['terms']['OnDemand'].iteritems():
-        for code, offer in offers.iteritems():
-            for key, dimension in offer['priceDimensions'].iteritems():
+    for sku, offers in six.iteritems(data['terms']['OnDemand']):
+        for code, offer in six.iteritems(offers):
+            for key, dimension in six.iteritems(offer['priceDimensions']):
 
                 # skip these for now
                 if any(descr in dimension['description'].lower() for descr in ['transfer', 'global', 'storage', 'iops', 'requests', 'multi-az']):
@@ -146,9 +148,9 @@ def scrape(output_file, input_file=None):
     }
 
     # Parse reserved pricing
-    for sku, offers in data['terms']['Reserved'].iteritems():
-        for code, offer in offers.iteritems():
-            for key, dimension in offer['priceDimensions'].iteritems():
+    for sku, offers in six.iteritems(data['terms']['Reserved']):
+        for code, offer in six.iteritems(offers):
+            for key, dimension in six.iteritems(offer['priceDimensions']):
 
                 # skip multi-az
                 if rds_instances[sku]['deploymentOption'] != 'Single-AZ':
@@ -180,9 +182,9 @@ def scrape(output_file, input_file=None):
     # print json.dumps(instances['db.m3.medium']['pricing']['eu-west-1']['MySQL'], indent=4)
 
     # Calculate all reserved effective pricings (upfront hourly + hourly price)
-    for instance_type, instance in instances.iteritems():
-        for region, pricing in instance['pricing'].iteritems():
-            for engine, prices in pricing.iteritems():
+    for instance_type, instance in six.iteritems(instances):
+        for region, pricing in six.iteritems(instance['pricing']):
+            for engine, prices in six.iteritems(pricing):
                 if 'reserved' not in prices:
                     continue
                 try:

--- a/render.py
+++ b/render.py
@@ -50,18 +50,18 @@ def render(data_file, template_file, destination_file):
     """Build the HTML content from scraped data"""
     lookup = mako.lookup.TemplateLookup(directories=['.'])
     template = mako.template.Template(filename=template_file, lookup=lookup)
-    print "Loading data from %s..." % data_file
+    print("Loading data from %s..." % data_file)
     with open(data_file) as f:
         instances = json.load(f)
     for i in instances:
         add_render_info(i)
-    print "Rendering to %s..." % destination_file
+    print("Rendering to %s..." % destination_file)
     generated_at = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S UTC')
     with io.open(destination_file, 'w', encoding="utf-8") as fh:
         try:
             fh.write(template.render(instances=instances, generated_at=generated_at))
         except:
-            print mako.exceptions.text_error_template().render()
+            print(mako.exceptions.text_error_template().render())
 
 if __name__ == '__main__':
     render('www/instances.json', 'in/index.html.mako', 'www/index.html')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-fabric<2.0.0
+invoke
+invocations
 boto
 mako
 lxml
-paramiko
-pycrypto
 requests==2.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ boto
 mako
 lxml
 requests==2.9.1
+six

--- a/scrape.py
+++ b/scrape.py
@@ -462,8 +462,8 @@ def fetch_data(url):
         pricing = json.loads(content)
     except ValueError:
         # if the data isn't compatible JSON, try to parse as jsonP
-        json_string = re.sub(r"(\w+):", r'"\1":',
-                             content[content.index('callback(') + 9: -2])  # convert into valid json
+        json_string = re.search(r'callback\((.*)\);', content).groups()[0]  # extract javascript object
+        json_string = re.sub(r"(\w+):", r'"\1":', json_string)  # convert to json
         pricing = json.loads(json_string)
 
     return pricing

--- a/scrape.py
+++ b/scrape.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 from lxml import etree
-import urllib2
 import re
 import json
 import locale
+
+from six.moves.urllib import request as urllib2
 
 # Following advice from https://stackoverflow.com/a/1779324/216138
 # The locale must be installed in the system, and it must be one where ',' is

--- a/scrape.py
+++ b/scrape.py
@@ -457,7 +457,7 @@ def add_pricing_info(instances):
 
 
 def fetch_data(url):
-    content = urllib2.urlopen(url).read()
+    content = urllib2.urlopen(url).read().decode()
     try:
         pricing = json.loads(content)
     except ValueError:
@@ -477,9 +477,9 @@ def add_eni_info(instances):
     by_type = {i.instance_type: i for i in instances}
 
     for r in rows:
-        instance_type = etree.tostring(r[0], method='text').strip()
-        max_enis = locale.atoi(etree.tostring(r[1], method='text'))
-        ip_per_eni = locale.atoi(etree.tostring(r[2], method='text'))
+        instance_type = etree.tostring(r[0], method='text').strip().decode()
+        max_enis = locale.atoi(etree.tostring(r[1], method='text').decode())
+        ip_per_eni = locale.atoi(etree.tostring(r[2], method='text').decode())
         if instance_type not in by_type:
             print("Unknown instance type: {}".format(instance_type))
             continue
@@ -681,7 +681,7 @@ def add_cpu_details(instances):
                 intel_turbo_idx = idx
         rows = [r for r in t.xpath('.//tr') if not text_for(r[0]) == 'Instance Type']
         for r in rows:
-            instance_type = sanitize_instance_type(etree.tostring(r[0], method='text'))
+            instance_type = sanitize_instance_type(etree.tostring(r[0], method='text').decode())
             instance = by_type.get(instance_type)
             if not instance:
                 print("Unknown instance type: {}".format(instance_type))

--- a/tasks.py
+++ b/tasks.py
@@ -46,8 +46,8 @@ def scrape_ec2(c):
     try:
         scrape(ec2_file)
     except Exception as e:
-        print "ERROR: Unable to scrape data: %s" % e
-        print traceback.print_exc()
+        print("ERROR: Unable to scrape data: %s" % e)
+        print(traceback.print_exc())
 
 
 @task
@@ -57,8 +57,8 @@ def scrape_rds(c):
     try:
         rds_scrape(rds_file)
     except Exception as e:
-        print "ERROR: Unable to scrape RDS data: %s" % e
-        print traceback.print_exc()
+        print("ERROR: Unable to scrape RDS data: %s" % e)
+        print(traceback.print_exc())
 
 
 @task
@@ -66,7 +66,7 @@ def serve(c):
     """Serve site contents locally for development"""
     os.chdir("www/")
     httpd = SocketServer.TCPServer((HTTP_HOST, int(HTTP_PORT)), SimpleHTTPServer.SimpleHTTPRequestHandler)
-    print "Serving on http://{}:{}".format(httpd.socket.getsockname()[0], httpd.socket.getsockname()[1])
+    print("Serving on http://{}:{}".format(httpd.socket.getsockname()[0], httpd.socket.getsockname()[1]))
     httpd.serve_forever()
 
 
@@ -83,18 +83,18 @@ def bucket_create(c):
     conn = connect_s3(calling_format=BUCKET_CALLING_FORMAT)
     bucket = conn.create_bucket(BUCKET_NAME, policy='public-read')
     bucket.configure_website('index.html', 'error.html')
-    print 'Bucket %r created.' % BUCKET_NAME
+    print('Bucket %r created.' % BUCKET_NAME)
 
 
 @task
 def bucket_delete(c):
     """Deletes the S3 bucket used to host the site"""
     if not confirm("Are you sure you want to delete the bucket %r?" % BUCKET_NAME):
-        print 'Aborting at user request.'
+        print('Aborting at user request.')
         exit(1)
     conn = connect_s3(calling_format=BUCKET_CALLING_FORMAT)
     conn.delete_bucket(BUCKET_NAME)
-    print 'Bucket %r deleted.' % BUCKET_NAME
+    print('Bucket %r deleted.' % BUCKET_NAME)
 
 
 @task
@@ -109,7 +109,7 @@ def deploy(c, root_dir='www'):
                 continue
             local_path = os.path.join(root, name)
             remote_path = local_path[len(root_dir) + 1:]
-            print '%s -> %s/%s' % (local_path, BUCKET_NAME, remote_path)
+            print('%s -> %s/%s' % (local_path, BUCKET_NAME, remote_path))
             k = Key(bucket)
             k.key = remote_path
             k.set_contents_from_filename(local_path, policy='public-read')

--- a/tasks.py
+++ b/tasks.py
@@ -3,8 +3,6 @@
 #   AWS_SECRET_ACCESS_KEY
 # as explained in: http://boto.s3.amazonaws.com/s3_tut.html
 
-import SimpleHTTPServer
-import SocketServer
 import os
 import traceback
 
@@ -13,6 +11,7 @@ from boto.s3.connection import OrdinaryCallingFormat
 from boto.s3.key import Key
 from invoke import task
 from invocations.console import confirm
+from six.moves import SimpleHTTPServer, socketserver
 
 from rds import scrape as rds_scrape
 from render import render
@@ -65,7 +64,7 @@ def scrape_rds(c):
 def serve(c):
     """Serve site contents locally for development"""
     os.chdir("www/")
-    httpd = SocketServer.TCPServer((HTTP_HOST, int(HTTP_PORT)), SimpleHTTPServer.SimpleHTTPRequestHandler)
+    httpd = socketserver.TCPServer((HTTP_HOST, int(HTTP_PORT)), SimpleHTTPServer.SimpleHTTPRequestHandler)
     print("Serving on http://{}:{}".format(httpd.socket.getsockname()[0], httpd.socket.getsockname()[1]))
     httpd.serve_forever()
 


### PR DESCRIPTION
**NOTE:** This PR is based on top of the branch which #381 was created from, so it also contains the same commits as they are a necessary predecessor for adding Python 3 support.

-----

This adds support for Python 3 to the code base alongside Python 2 support. The [six](https://six.readthedocs.io/) library was used in a few places to be able to support both, but shouldn't be intrusive at all.

I have tries to make each commit concerned with only one aspect of this, so I'd suggest going through them one by one to get a better idea of what has changed.