### PR TITLE
add link to site from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ec2instances.info
 
-I was sick of comparing EC2 instance metrics and pricing on Amazon's site so I made this. Improvements welcome!
+I was sick of comparing EC2 instance metrics and pricing on Amazon's site so I made [ec2instances.info](https://ec2instances.info). Improvements welcome!
 
 
 ### Project status


### PR DESCRIPTION
I noticed the README doesn't actually link to the production site, so I added that link.