### PR TITLE
adding new AWS regions (Paris, Osaka, GovCloud East)

### DIFF
--- a/in/index.html.mako
+++ b/in/index.html.mako
@@ -34,7 +34,8 @@
             <li><a href="javascript:;" data-region='us-east-2'>US East (Ohio)</a></li>
             <li><a href="javascript:;" data-region='us-west-1'>US West (Northern California)</a></li>
             <li><a href="javascript:;" data-region='us-west-2'>US West (Oregon)</a></li>
-            <li><a href="javascript:;" data-region='us-gov-west-1'>AWS GovCloud (US)</a></li>
+            <li><a href="javascript:;" data-region='us-gov-west-1'>AWS GovCloud (US-West)</a></li>
+            <li><a href="javascript:;" data-region='us-gov-east-1'>AWS GovCloud (US-East)</a></li>
           </ul>
         </div>
 

--- a/in/rds.html.mako
+++ b/in/rds.html.mako
@@ -19,6 +19,7 @@
           </a>
           <ul class="dropdown-menu" role="menu">
             <li><a href="javascript:;" data-region='ap-south-1'>Asia-Pacific (Mumbai)</a></li>
+            <li><a href="javascript:;" data-region='ap-northeast-3'>Asia Pacific (Osaka-Local)</a></li>
             <li><a href="javascript:;" data-region='ap-northeast-2'>Asia-Pacific (Seoul)</a></li>
             <li><a href="javascript:;" data-region='ap-southeast-1'>Asia-Pacific (Singapore)</a></li>
             <li><a href="javascript:;" data-region='ap-southeast-2'>Asia-Pacific (Sydney)</a></li>
@@ -27,12 +28,14 @@
             <li><a href="javascript:;" data-region='eu-central-1'>EU (Frankfurt)</a></li>
             <li><a href="javascript:;" data-region='eu-west-1'>EU (Ireland)</a></li>
             <li><a href="javascript:;" data-region='eu-west-2'>EU (London)</a></li>
+            <li><a href="javascript:;" data-region='eu-west-3'>EU (Paris)</a></li>
             <li><a href="javascript:;" data-region='sa-east-1'>South America (S&atilde;o Paulo)</a></li>
             <li><a href="javascript:;" data-region='us-east-1'>US East (N. Virginia)</a></li>
             <li><a href="javascript:;" data-region='us-east-2'>US East (Ohio)</a></li>
             <li><a href="javascript:;" data-region='us-west-1'>US West (Northern California)</a></li>
             <li><a href="javascript:;" data-region='us-west-2'>US West (Oregon)</a></li>
-            <li><a href="javascript:;" data-region='us-gov-west-1'>AWS GovCloud (US)</a></li>
+            <li><a href="javascript:;" data-region='us-gov-west-1'>AWS GovCloud (US-West)</a></li>
+            <li><a href="javascript:;" data-region='us-gov-east-1'>AWS GovCloud (US-East)</a></li>
           </ul>
         </div>
 

--- a/rds.py
+++ b/rds.py
@@ -69,7 +69,8 @@ def scrape(output_file, input_file=None):
 
     # region mapping, someone thought it was handy not to include the region id's :(
     regions = {
-        "AWS GovCloud (US)": 'us-gov-west-1',
+        "AWS GovCloud (US-West)": 'us-gov-west-1',
+        "AWS GovCloud (US-East)": 'us-gov-east-1',
         "Asia Pacific (Mumbai)": 'ap-south-1',
         "Asia Pacific (Seoul)": 'ap-northeast-2',
         "Asia Pacific (Singapore)": 'ap-southeast-1',


### PR DESCRIPTION
https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/
still looking into adding the China regions as well, because those didn't show any prices this way

Would be nice to get all of the region mapping in one central place too