### PR TITLE
Fix instance families (#401)

### DIFF
--- a/ec2.py
+++ b/ec2.py
@@ -177,7 +177,7 @@ def parse_instance(instance_type, product_attributes):
         # May be a good idea to all dedicated hosts in the future
         return
 
-    i.family = pieces[0]
+    i.family = product_attributes.get('instanceFamily')
 
     if '32-bit' in product_attributes.get('processorArchitecture'):
         i.arch.append('i386')


### PR DESCRIPTION
Fix the regression in #401 
It should match the output for `curl -sL https://github.com/powdahound/ec2instances.info/raw/9692781cf5fc9410fbb0d9532afcb97fb6f52483/www/instances.json | jq '.[] | {type: .instance_type, family: .family}'` but it may differ a bit.