### PR TITLE
Add support for column filters

### DIFF
--- a/www/default.js
+++ b/www/default.js
@@ -15,6 +15,18 @@ var g_settings_defaults = {
 };
 
 function init_data_table() {
+  // create a second header row
+  $("#data thead tr").clone(true).appendTo("#data thead");
+  // add a text input filter to each column of the new row
+  $("#data thead tr:eq(1) th").each(function (i) {
+    var title = $(this).text();
+    $(this).html("<input type='text' placeholder='Search '" + title + "' />");
+    $("input", this).on( "keyup change", function () {
+      if (g_data_table.column(i).search() !== this.value) {
+        g_data_table.column(i).search(this.value).draw();
+      }
+    });
+  });
   g_data_table = $('#data').DataTable({
     "bPaginate": false,
     "bInfo": false,


### PR DESCRIPTION
# What is this?
I love ec2instances.info, I use it frequently. EC2 instance shopping is intrinsically an optimization problem. You always know your instance requirements and you're trying to find the best fit for the lowest cost. It is a constraint-based problem as well. You have "soft" and "hard" constraints, meaning things you can and cannot compromise in your search, respectively.

# The problem
Say I have a hard constraint on storage, "EBS only" and network performance of "High" but a soft constraint on RAM and CPU. The ec2instances site in its current state is difficult because I have only one search textbox for my hard constraints, I can search by one or the other. The end result is I search by one of these constraints, sort on the other, and spend significant time sorting and scrolling to compare the instances I can consider, but I lack a fine-grain filter.

# The proposed solution
By adding a text-input column filter to the top of each column I can set each of my hard constraints specifically and sort by my soft constraints, getting me to the concise options much quicker. Note that I'm only proposing adding this new filter mechanism, not removing nor changing any existing functionality. Try it out!

![image](https://user-images.githubusercontent.com/2430664/53645453-e6bb0f80-3c06-11e9-9444-8ec043c9ed28.png)
