### PR TITLE
Ensure first row in the table has sorting control

### DIFF
--- a/www/default.js
+++ b/www/default.js
@@ -31,6 +31,7 @@ function init_data_table() {
     "bPaginate": false,
     "bInfo": false,
     "bStateSave": true,
+    "orderCellsTop": true,
     "oSearch": {
       "bRegex": true,
       "bSmart": false


### PR DESCRIPTION
# What is this?
My apologies. It appears my column sorting introduced a minor bug. This PR is a fix for the bug.
To build column sorting a second "table-header" row is added to the table at initialization time.
It turns out that DataTables, by default, places column sorting controls on the lowest "table-header" row.
I personally believe in our case column sorting should remain the same as it always has, on the top row.
See this screenshot as an example:
![image](https://user-images.githubusercontent.com/2430664/53683034-3ca4bb80-3cca-11e9-8b59-f3ad75fe6371.png)

I ironically discovered this bug this morning when using your site to shop for a new EC2 instance.
Fortunately, thanks to the power of DataTables, the fix is very basic. Change the default behavior and enforce the top-header-row controls the sorting by [setting "orderCellsTop" to true](https://datatables.net/reference/option/orderCellsTop).

The end result looks like this (proving the correctness in the PR):
![image](https://user-images.githubusercontent.com/2430664/53683118-37943c00-3ccb-11e9-9178-46e864cbecb5.png)

Again my apologies on the bug. 
