### PR TITLE
Improve page load speed

### DIFF
--- a/in/base.mako
+++ b/in/base.mako
@@ -58,6 +58,21 @@
     <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/buttons/1.2.4/js/buttons.html5.min.js"></script>
     <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/buttons/1.2.4/js/buttons.print.min.js"></script>
     <script src="/store/store.js" type="text/javascript" charset="utf-8"></script>
+    <script type="text/javascript">
+        var _pricing = ${pricing_json};
+        function get_pricing() {
+            // see compress_pricing in render.py for the generation side
+            v = _pricing["data"];
+            for (var i = 0; i < arguments.length; i++) {
+                k = _pricing["index"][arguments[i]];
+                v = v[k];
+                if (v === undefined) {
+                    return undefined;
+                }
+            }
+            return v;
+        }
+    </script>
     <script src="/default.js" type="text/javascript" charset="utf-8"></script>
 
     <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>

--- a/in/index.html.mako
+++ b/in/index.html.mako
@@ -358,7 +358,7 @@
           ## note that the contents in these cost cells are overwritten by the JS change_cost() func, but the initial
           ## data here is used for sorting (and anyone with JS disabled...)
           ## for more info, see https://github.com/powdahound/ec2instances.info/issues/140
-          <td class="cost-ondemand cost-ondemand-${platform}" data-pricing='${json.dumps({r:p.get(platform, p.get('os',{})).get('ondemand') for r,p in six.iteritems(inst['pricing'])}) | h}'>
+          <td class="cost-ondemand cost-ondemand-${platform}" data-platform="${platform}">
             % if inst['pricing'].get('us-east-1', {}).get(platform, {}).get('ondemand', 'N/A') != "N/A":
               <span sort="${inst['pricing']['us-east-1'][platform]['ondemand']}">
                 $${inst['pricing']['us-east-1'][platform]['ondemand']} hourly
@@ -367,7 +367,7 @@
               <span sort="999999">unavailable</span>
             % endif
           </td>
-          <td class="cost-reserved cost-reserved-${platform}" data-pricing='${json.dumps({r:p.get(platform, p.get('os',{})).get('reserved', {}) for r,p in six.iteritems(inst['pricing'])}) | h}'>
+          <td class="cost-reserved cost-reserved-${platform}" data-platform="${platform}">
             % if inst['pricing'].get('us-east-1', {}).get(platform, {}).get('reserved', 'N/A') != "N/A" and inst['pricing']['us-east-1'][platform]['reserved'].get('yrTerm1Standard.noUpfront', 'N/A') != "N/A":
               <span sort="${inst['pricing']['us-east-1'][platform]['reserved']['yrTerm1Standard.noUpfront']}">
                 $${inst['pricing']['us-east-1'][platform]['reserved']['yrTerm1Standard.noUpfront']} hourly
@@ -377,7 +377,7 @@
             % endif
           </td>
           % endfor
-          <td class="cost-ebs-optimized" data-pricing='${json.dumps({r:p.get('ebs', {}) for r,p in six.iteritems(inst['pricing'])}) | h}'>
+          <td class="cost-ebs-optimized">
            % if inst['ebs_max_bandwidth']:
               % if inst['pricing'].get('us-east-1', {}).get('ebs', 'N/A') != "N/A":
                 <span sort="${inst['pricing']['us-east-1']['ebs']}">
@@ -390,7 +390,7 @@
               <span sort="999999">unavailable</span>
             % endif
           </td>
-          <td class="cost-emr cost-ondemand" data-pricing='${json.dumps({r:p.get('emr', {}).get('emr', {}) for r,p in six.iteritems(inst['pricing'])}) | h}'>
+          <td class="cost-emr">
             % if inst['pricing'].get('us-east-1', {}).get("emr", {}):
               <span sort="${inst['pricing']['us-east-1']["emr"]['emr']}">
                 $${inst['pricing']['us-east-1']["emr"]['emr']} hourly

--- a/in/rds.html.mako
+++ b/in/rds.html.mako
@@ -162,7 +162,7 @@
             % endif
           </td>
           % for platform in ['Aurora PostgreSQL', 'Aurora MySQL', 'MariaDB', 'MySQL', 'Oracle','PostgreSQL', 'SQL Server']:
-          <td class="cost-ondemand cost-ondemand-${platform}" data-pricing='${json.dumps({r:p.get(platform, p.get('os',{})).get('ondemand') for r,p in six.iteritems(inst['pricing'])}) | h}'>
+          <td class="cost-ondemand cost-ondemand-${platform}" data-platform='${platform}'>
             % if inst['pricing'].get('us-east-1', {}).get(platform, {}).get('ondemand', 'N/A') != "N/A":
               <span sort="${inst['pricing']['us-east-1'][platform]['ondemand']}">
                 $${inst['pricing']['us-east-1'][platform]['ondemand']} per hour
@@ -171,7 +171,7 @@
               <span sort="0">unavailable</span>
             % endif
           </td>
-          <td class="cost-reserved cost-reserved-${platform}" data-pricing='${json.dumps({r:p.get(platform, p.get('os',{})).get('reserved', {}) for r,p in six.iteritems(inst['pricing'])}) | h}'>
+          <td class="cost-reserved cost-reserved-${platform}" data-platform='${platform}'>
             % if inst['pricing'].get('us-east-1', {}).get(platform, {}).get('reserved', 'N/A') != "N/A":
               <span sort="${inst['pricing']['us-east-1'][platform]['reserved'].get('yrTerm1.noUpfront')}">
                 $${inst['pricing']['us-east-1'][platform]['reserved'].get('yrTerm1.noUpfront')} per hour

--- a/render.py
+++ b/render.py
@@ -46,6 +46,42 @@ def add_render_info(i):
     add_cpu_detail(i)
 
 
+prices_dict = {}
+prices_index = 0
+
+
+def _compress_pricing(d):
+    global prices_index
+
+    for k, v in d.items():
+        if k in prices_dict:
+            nk = prices_dict[k]
+        else:
+            prices_dict[k] = nk = prices_index
+            prices_index += 1
+
+        if isinstance(v, dict):
+            nv = dict(_compress_pricing(v))
+        else:
+            nv = v
+
+        yield nk, nv
+
+
+def compress_pricing(instances):
+    global prices_index
+
+    prices = {
+        i['instance_type']: i['pricing']
+        for i in instances
+    }
+
+    prices_dict.clear()
+    prices_index = 0
+
+    return json.dumps({"index": prices_dict, "data": dict(_compress_pricing(prices))})
+
+
 def render(data_file, template_file, destination_file):
     """Build the HTML content from scraped data"""
     lookup = mako.lookup.TemplateLookup(directories=['.'])
@@ -55,13 +91,15 @@ def render(data_file, template_file, destination_file):
         instances = json.load(f)
     for i in instances:
         add_render_info(i)
+    pricing_json = compress_pricing(instances)
     print("Rendering to %s..." % destination_file)
     generated_at = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S UTC')
     with io.open(destination_file, 'w', encoding="utf-8") as fh:
         try:
-            fh.write(template.render(instances=instances, generated_at=generated_at))
+            fh.write(template.render(instances=instances, pricing_json=pricing_json, generated_at=generated_at))
         except:
             print(mako.exceptions.text_error_template().render())
+
 
 if __name__ == '__main__':
     render('www/instances.json', 'in/index.html.mako', 'www/index.html')

--- a/www/default.js
+++ b/www/default.js
@@ -174,7 +174,7 @@ function change_cost(duration) {
   var per_time;
   $.each($("td.cost-ondemand"), function (i, elem) {
     elem = $(elem);
-    per_time = elem.data("pricing")[g_settings.region];
+    per_time = get_pricing(elem.closest("tr").attr("id"), g_settings.region, elem.data("platform"), "ondemand");
     if (per_time && !isNaN(per_time)) {
       per_time = (per_time * multiplier).toFixed(6);
       elem.html('<span sort="' + per_time + '">$' + per_time + ' ' + duration + '</span>');
@@ -185,14 +185,7 @@ function change_cost(duration) {
 
   $.each($("td.cost-reserved"), function (i, elem) {
     elem = $(elem);
-    per_time = elem.data("pricing")[g_settings.region];
-
-    if (!per_time) {
-      elem.html('<span sort="999999">unavailable</span>');
-      return;
-    }
-
-    per_time = per_time[g_settings.reserved_term];
+    per_time = get_pricing(elem.closest("tr").attr("id"), g_settings.region, elem.data("platform"), "reserved", g_settings.reserved_term);
 
     if (per_time && !isNaN(per_time)) {
       per_time = (per_time * multiplier).toFixed(6);
@@ -204,7 +197,18 @@ function change_cost(duration) {
 
   $.each($("td.cost-ebs-optimized"), function (i, elem) {
     elem = $(elem);
-    per_time = elem.data("pricing")[g_settings.region];
+    per_time = get_pricing(elem.closest("tr").attr("id"), g_settings.region, "ebs");
+    if (per_time && !isNaN(per_time)) {
+      per_time = (per_time * multiplier).toFixed(6);
+      elem.html('<span sort="' + per_time + '">$' + per_time + ' ' + duration + '</span>');
+    } else {
+      elem.html('<span sort="999999">unavailable</span>');
+    }
+  });
+
+  $.each($("td.cost-emr"), function (i, elem) {
+    elem = $(elem);
+    per_time = get_pricing(elem.closest("tr").attr("id"), g_settings.region, "emr", "emr");
     if (per_time && !isNaN(per_time)) {
       per_time = (per_time * multiplier).toFixed(6);
       elem.html('<span sort="' + per_time + '">$' + per_time + ' ' + duration + '</span>');


### PR DESCRIPTION
Even with a very decent internet connection, the page takes a few good seconds to load. A big part of it seems to be all the serialized JSON data in a lot of the columns. You can actually see Chrome drawing it row by row as it's loading.

I've changed it up a little so that all the pricing data is in one big object at the end of the file. This way the browser can load the initial table, display it, and then load the rest of the data.

I've also "compressed" the pricing dictionary by using integers for the keys instead of long strings like `"yrTerm1Convertible.partialUpfront`" that repeat for each instance type and each region.

Those two together reduced `index.html` from 16mb to 5.7mb (uncompressed). It also feels like it loads faster because you don't see the row by row rendering.

I hope this is something you'd consider merging, because it would make my life much better. I load this page multiple times a day and the multiple seconds of loading add up especially when I'm in a meeting and just trying to quickly figure out some prices.