### PR TITLE
adding more network performance sorting options

### DIFF
--- a/render.py
+++ b/render.py
@@ -16,7 +16,12 @@ def network_sort(inst):
         'High',
         'Up to 10 Gigabit',
         '10 Gigabit',
-        '20 Gigabit'
+        '12 Gigabit',
+        '20 Gigabit',
+        'Up to 25 Gigabit',
+        '25 Gigabit',
+        '50 Gigabit',
+        '100 Gigabit',
     ]
     try:
         sort = network_rank.index(perf)


### PR DESCRIPTION
https://github.com/powdahound/ec2instances.info/issues/350

Quick fix. We could make this more future-proof by parsing the numbers out of text. Would be even easier if we can drop the `Up to ` that's in some of the cells