### PR TITLE
Add Bahrain region + fix build errors cause by Bahrain

### DIFF
--- a/ec2.py
+++ b/ec2.py
@@ -119,15 +119,19 @@ def add_pricing(imap):
             platform = translate_platform_name(operating_system, preinstalled_software)
 
             instance_type = product_attributes.get('instanceType')
-            inst = imap[instance_type]
-
-            inst.pricing.setdefault(region, {})
-            inst.pricing[region].setdefault(platform, {})
-            inst.pricing[region][platform]['ondemand'] = get_ondemand_pricing(terms)
-            # Some instances don't offer reserved terms at all
-            reserved = get_reserved_pricing(terms)
-            if reserved:
-                inst.pricing[region][platform]['reserved'] = reserved
+            # If the instance type is not in us-east-1 imap[instance_type] could fail
+            try:
+                inst = imap[instance_type]
+                inst.pricing.setdefault(region, {})
+                inst.pricing[region].setdefault(platform, {})
+                inst.pricing[region][platform]['ondemand'] = get_ondemand_pricing(terms)
+                # Some instances don't offer reserved terms at all
+                reserved = get_reserved_pricing(terms)
+                if reserved:
+                    inst.pricing[region][platform]['reserved'] = reserved
+            except:
+                # print more details about the instance for debugging
+                print(json.dumps(product_attributes))
 
 
 def format_price(price):

--- a/in/index.html.mako
+++ b/in/index.html.mako
@@ -31,6 +31,7 @@
             <li><a href="javascript:;" data-region='eu-west-2'>EU (London)</a></li>
             <li><a href="javascript:;" data-region='eu-west-3'>EU (Paris)</a></li>
             <li><a href="javascript:;" data-region='eu-north-1'>EU (Stockholm)</a></li>
+            <li><a href="javascript:;" data-region='me-south-1'>Middle East (Bahrain)</a></li>
             <li><a href="javascript:;" data-region='sa-east-1'>South America (S&atilde;o Paulo)</a></li>
             <li><a href="javascript:;" data-region='us-east-1'>US East (N. Virginia)</a></li>
             <li><a href="javascript:;" data-region='us-east-2'>US East (Ohio)</a></li>

--- a/in/rds.html.mako
+++ b/in/rds.html.mako
@@ -31,6 +31,7 @@
             <li><a href="javascript:;" data-region='eu-west-2'>EU (London)</a></li>
             <li><a href="javascript:;" data-region='eu-west-3'>EU (Paris)</a></li>
             <li><a href="javascript:;" data-region='eu-north-1'>EU (Stockholm)</a></li>
+            <li><a href="javascript:;" data-region='me-south-1'>Middle East (Bahrain)</a></li>
             <li><a href="javascript:;" data-region='sa-east-1'>South America (S&atilde;o Paulo)</a></li>
             <li><a href="javascript:;" data-region='us-east-1'>US East (N. Virginia)</a></li>
             <li><a href="javascript:;" data-region='us-east-2'>US East (Ohio)</a></li>


### PR DESCRIPTION
We have a new region available so it added it to the menus.

Additionally it seems that Bahrain contains a few new instance types (c5d.metal, cd5.12xl, c5d.24xl) that are not in us-east-1 so are not parsed correctly. I've added a try/catch to prevent the task from failing, hopefully they will be added to N. Virginia soon. Otherwise 

Also the Travis CI is currently showing the build as passing while it actually should be failed.