### PR TITLE
Fix network speed sorting

### DIFF
--- a/render.py
+++ b/render.py
@@ -21,6 +21,7 @@ def network_sort(inst):
         'Up to 25 Gigabit',
         '25 Gigabit',
         '50 Gigabit',
+        '75 Gigabit',
         '100 Gigabit',
     ]
     try:


### PR DESCRIPTION
The '75 Gigabit' option was missing and the index defaulted to zero. This should fix that

At this time, sorting by network speed shows 75 Gigabits before 100 - which is wrong.