### PR TITLE
Issue 479 - Filter out Outposts

### DIFF
--- a/rds.py
+++ b/rds.py
@@ -100,11 +100,13 @@ def scrape(output_file, input_file=None):
             attributes['arch'] = attributes['processorArchitecture']
             attributes['pricing'] = {}
             attributes['pricing'][region] = {}
-            rds_instances[sku] = attributes
 
-            if instance_type not in instances.keys():
-                instances[instance_type] = attributes
-                instances[instance_type]['pricing'] = {}
+            if attributes['engineCode'] not in ['210', '220']:
+                rds_instances[sku] = attributes
+
+                if instance_type not in instances.keys():
+                    instances[instance_type] = attributes
+                    instances[instance_type]['pricing'] = {}
 
     # Parse ondemand pricing
     for sku, offers in six.iteritems(data['terms']['OnDemand']):


### PR DESCRIPTION
Addresses #479 
I have no way of confirming if 210 and 220 are the only required `engineCode` to ignore but they seem to reflect Outpost running of MySQL and PostgreSQL
Have built and confirmed this resolves the issues reported there - diff of old and new instances.json makes sense.
(there are plenty of errors reported as in other PRs due to unknown sku)