### PR TITLE
Add "Up to 5 Gigabit" to the network performance sort order

### DIFF
--- a/ec2.py
+++ b/ec2.py
@@ -45,8 +45,6 @@ def get_region_descriptions():
 
     # The Osaka region is invite only and not in boto's list: https://github.com/boto/botocore/issues/1423
     result['Asia Pacific (Osaka-Local)'] = 'ap-northeast-3'
-    # Alias GovCloud US-West to GovCloud US
-    result['AWS GovCloud (US-West)'] = result['AWS GovCloud (US)']
     # Alias LA local zone to its home region
     result['US West (Los Angeles)'] = 'us-west-2'
 

--- a/render.py
+++ b/render.py
@@ -14,6 +14,7 @@ def network_sort(inst):
         'Low to Moderate',
         'Moderate',
         'High',
+        'Up to 5 Gigabit',
         'Up to 10 Gigabit',
         '10 Gigabit',
         '12 Gigabit',


### PR DESCRIPTION
This fixes #487 

Also remove an unneeded region alias workaround.