### PR TITLE
Use the instance type data to populate the architecture list

### DIFF
--- a/ec2.py
+++ b/ec2.py
@@ -219,17 +219,21 @@ def parse_instance(instance_type, product_attributes, api_description):
 
     i.family = product_attributes.get('instanceFamily')
 
-    if '32-bit' in product_attributes.get('processorArchitecture'):
-        i.arch.append('i386')
-
     i.vCPU = locale.atoi(product_attributes.get('vcpu'))
 
     # Memory is given in form of "1,952 GiB", let's parse it
     i.memory = locale.atof(product_attributes.get('memory').split(' ')[0])
 
     if api_description:
+        i.arch = api_description['ProcessorInfo']['SupportedArchitectures']
+
         i.network_performance = api_description['NetworkInfo']['NetworkPerformance']
     else:
+        # Assume x86_64 if there's no DescribeInstanceTypes data.
+        i.arch.append('x86_64')
+        if '32-bit' in product_attributes.get('processorArchitecture'):
+            i.arch.append('i386')
+
         i.network_performance = product_attributes.get('networkPerformance')
 
     if product_attributes.get('currentGeneration') == 'Yes':

--- a/scrape.py
+++ b/scrape.py
@@ -15,7 +15,7 @@ locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
 
 class Instance(object):
     def __init__(self):
-        self.arch = ['x86_64']
+        self.arch = []
         self.api_description = None
         self.base_performance = None
         self.burst_minutes = None


### PR DESCRIPTION
AWS currently has support for both the x86 and ARM architectures, so the old assumption that everything was x86_64 unless there was a 32-bit pricing option doesn't apply.  Fortunately, AWS provides the list of supported architectures as part of the DescribeInstanceTypes call, so we can will support any new architectures that they come out with.